### PR TITLE
ページロード時にトグルがオンの場合，オフにしても機能がオフにならないエラーを修正

### DIFF
--- a/background.js
+++ b/background.js
@@ -5,12 +5,10 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
     if (url && (url.startsWith("https://chat.openai.com/chat") ||
                 url.startsWith("https://poe.com") ||
                 url.startsWith("https://www.phind.com"))) {
-      chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
-      chrome.action.enable(tabId);
-      chrome.scripting.executeScript({
-        target: { tabId: tabId },
-        files: ["script.js"],
-      });
+        if (changeInfo.status === "complete") {
+          chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
+          chrome.action.enable(tabId);
+        }
     } else {
       chrome.action.disable(tabId);
       chrome.action.setIcon({ path: "icon/na.png" });


### PR DESCRIPTION
### 前提

`chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {})`はロード時に何度も呼ばれる

<img width="555" alt="image" src="https://user-images.githubusercontent.com/38304912/229644240-d9091778-34c7-4dc7-ada1-ff66cd30daa7.png">

### 現状

↑によってページに`script.js`が複数読み込まれている（そのうち一回は`content_scripts`によるもの）．

### 問題

これが原因で`document.removeEventListener`がうまく動作していない（何故かまでは分かってないけど，同名関数とそのリスナー登録が複数定義されてるのでなんらかの不具合が起きるのは分かる）．

### 解決方法

`script.js`の読み込み回数を一回にする．そのためにインジェクションをやめて`content_scripts`による読み込みのみに限定した

※ `content_scripts`を消して，`background.js`内で`changeInfo.status === "complete"`の時に読み込みするようにしてもこの問題は解決することを確認済みである（一応，`changeInfo.status === "complete"`でアイコン設定と活性化を制御するように修正したのでそこにインジェクションのコードを書くとうまく動作する）．