### PR TITLE
特定のURL以外でトグルを切り替えるアイコンが切り替わらない事象を修正

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -15,7 +15,7 @@ toggleButton.addEventListener("change", () => {
 
 function updateIcon() {
   chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    const url = tabs[0].url;
+    const url = tabs[0].url ?? "";
     if (url.startsWith("https://chat.openai.com") ||
         url.startsWith("https://poe.com") ||
         url.startsWith("https://www.phind.com")) {


### PR DESCRIPTION
素敵な拡張機能を提供いただき、ありがとうございます。
たまたま使っていて気づいた部分を修正してみましたので、必要に応じてレビュー、マージの検討をよろしくおねがいします。

## 事象

許可していない URL 上でトグルを切り替えると、拡張機能のアイコンが切り替わらないようでした。
原因としては、`url` が undefined となることがあり、undefined に対して、startsWith メソッドを実行しようとして TypeError となるためです。

## 解決方法

`url` が undefined の場合は、`""` (string型) となるように、処理を修正しました。
