### PR TITLE
[fix] Firefox版で拡張機能のオンオフができない問題を修正

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,12 @@
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "addon_id_temp@example.com",
+      "strict_min_version": "42.0"
+    }
+  },
   "permissions": [
     "storage",
     "https://chat.openai.com/*",

--- a/popup.js
+++ b/popup.js
@@ -8,9 +8,9 @@ chrome.storage.sync.get("isEnabled", (data) => {
   updateIcon();
 });
 
-toggleButton.addEventListener("change", () => {
+toggleButton.addEventListener("change", async () => {
   isEnabled = toggleButton.checked;
-  chrome.storage.sync.set({ isEnabled });
+  await browser.storage.sync.set({ isEnabled });
   updateIcon();
 });
 


### PR DESCRIPTION
 Firefox版で拡張機能のオンオフができない問題を修正

`chrome.storage.sync.set`を`browser.storage.sync.set`に変更
その際に、add-on IDが必要になったため、manifest.jsonにidとして`addon_id_temp@example.com`を一時的に追加

close #23 