### PR TITLE
編集モードでも機能するよう修正

### DIFF
--- a/script.js
+++ b/script.js
@@ -3,12 +3,30 @@
 // });
 
 function handleCtrlEnter(event) {
-  if (
-    event.target.tagName === "TEXTAREA" &&
-    event.code == "Enter" &&
-    !(event.ctrlKey || event.metaKey)
-  ) {
-    event.stopPropagation();
+  if (event.target.id === "prompt-textarea") {
+    if (
+      event.target.tagName === "TEXTAREA" &&
+      event.code == "Enter" &&
+      !(event.ctrlKey || event.metaKey)
+    ) {
+      event.stopPropagation();
+    }
+  } else {
+    if (event.target === document.querySelectorAll("textarea")[0]) {
+      if (event.ctrlKey && event.code == "Enter") {
+        event.stopPropagation();
+
+        const newEvent = new KeyboardEvent("keydown", {
+          bubbles: true,
+          cancelable: true,
+          key: "Enter",
+          code: "Enter",
+          ctrlKey: false,
+          metaKey: true
+        });
+        event.target.dispatchEvent(newEvent);
+      }
+    }
   }
 }
 

--- a/script.js
+++ b/script.js
@@ -14,8 +14,6 @@ function handleCtrlEnter(event) {
   } else {
     if (event.target === document.querySelectorAll("textarea")[0]) {
       if (event.ctrlKey && event.code == "Enter") {
-        event.stopPropagation();
-
         const newEvent = new KeyboardEvent("keydown", {
           bubbles: true,
           cancelable: true,

--- a/script.js
+++ b/script.js
@@ -3,7 +3,7 @@
 // });
 
 function handleCtrlEnter(event) {
-  const url = window.location.href
+  const url = window.location.href;
   if (!url.startsWith("https://chat.openai.com") || event.target.id === "prompt-textarea") {
     if (
       event.target.tagName === "TEXTAREA" &&
@@ -13,18 +13,16 @@ function handleCtrlEnter(event) {
       event.stopPropagation();
     }
   } else {
-    if (event.target === document.querySelectorAll("textarea")[0]) {
-      if (event.ctrlKey && event.code == "Enter") {
-        const newEvent = new KeyboardEvent("keydown", {
-          bubbles: true,
-          cancelable: true,
-          key: "Enter",
-          code: "Enter",
-          ctrlKey: false,
-          metaKey: true
-        });
-        event.target.dispatchEvent(newEvent);
-      }
+    if (event.ctrlKey && event.code == "Enter") {
+      const newEvent = new KeyboardEvent("keydown", {
+        bubbles: true,
+        cancelable: true,
+        key: "Enter",
+        code: "Enter",
+        ctrlKey: false,
+        metaKey: true
+      });
+      event.target.dispatchEvent(newEvent);
     }
   }
 }

--- a/script.js
+++ b/script.js
@@ -3,7 +3,8 @@
 // });
 
 function handleCtrlEnter(event) {
-  if (event.target.id === "prompt-textarea") {
+  const url = window.location.href
+  if (!url.startsWith("https://chat.openai.com") || event.target.id === "prompt-textarea") {
     if (
       event.target.tagName === "TEXTAREA" &&
       event.code == "Enter" &&


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please:
* Associate an issue with the Pull Request.
* Ensure that the code is up-to-date with the `main` branch.
* Include a description of the proposed changes and how to test them.
-->

## 概要

編集モードで拡張機能が動作しないバグを修正した．

## 背景

編集用テキストエリアでは，送信イベント伝搬のトリガーが異なることが原因だと判明した．
- デフォルトのテキストエリア：`Enter`で送信イベントが発火する
- 編集用のテキストエリア：`Enter`で送信イベントが発火しない

加えて，Macなどのキーボードに搭載されている`Command`キーと`Enter`を組み合わせると送信できるようになっている

## 変更点

上記の背景を踏まえて以下の変更を加えた．

- キーダウンイベントのターゲットがデフォルトのテキストエリアか編集用テキストエリアかを判別する
- 編集用テキストエリアがターゲットの場合，`Control`と`Enter`が押された場合，`Command`と`Enter`が押されたとするイベントを自作し手動で発火する

## 関連Issue

- #17 