### PR TITLE
Add support for Claude (https://claude.ai)

### DIFF
--- a/background.js
+++ b/background.js
@@ -7,7 +7,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
                 url.startsWith("https://www.phind.com") ||
                 url.startsWith("https://chat.mistral.ai") ||
                 url.startsWith("https://www.chatpdf.com") ||
-                url.startsWith("https://www.perplexity.ai"))) {
+                url.startsWith("https://www.perplexity.ai") ||
+                url.startsWith("https://claude.ai"))) {
         if (changeInfo.status === "complete") {
           chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
           chrome.action.enable(tabId);

--- a/manifest.json
+++ b/manifest.json
@@ -23,6 +23,11 @@
         "https://www.perplexity.ai/*"
       ],
       "js": ["script.js"]
+    },
+    {
+      "matches": ["https://claude.ai/*"],
+      "js": ["script_claude.js"],
+      "run_at": "document_start"
     }
   ],
   "icons": {
@@ -36,7 +41,8 @@
     "https://www.phind.com/*",
     "https://chat.mistral.ai/*",
     "https://www.chatpdf.com/*",
-    "https://www.perplexity.ai/*"
+    "https://www.perplexity.ai/*",
+    "https://claude.ai/*"
   ],
   "action": {
     "default_popup": "popup.html",

--- a/popup.js
+++ b/popup.js
@@ -21,7 +21,8 @@ function updateIcon() {
         url.startsWith("https://www.phind.com") ||
         url.startsWith("https://chat.mistral.ai") ||
         url.startsWith("https://www.chatpdf.com") ||
-        url.startsWith("https://www.perplexity.ai")) {
+        url.startsWith("https://www.perplexity.ai") ||
+        url.startsWith("https://claude.ai")) {
       chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
     }
   });

--- a/script_claude.js
+++ b/script_claude.js
@@ -1,0 +1,45 @@
+let isHandleCtrlEnterEnabled = false;
+
+function handleCtrlEnter(event) {
+  if (!isHandleCtrlEnterEnabled){
+    return;
+  }
+  if (event.target.tagName !== "DIV" || event.target.contentEditable !== "true"){
+    return;
+  }
+
+  const noModifierKeysDown = !(event.ctrlKey || event.shiftKey || event.metaKey)
+  if (event.code == "Enter" && noModifierKeysDown){
+    // Cancel Enter without any modifier key (Ctrl, Shift, meta)
+    // Enter with Shift must NOT be canceled to prevent infinite loop
+    event.preventDefault(); // Claude prevents default keydown event, so do I.
+    event.stopImmediatePropagation(); // Cancel keydown event handler of Claude
+
+    // Dispatch Shift+Enter instead
+    const newEvent = new KeyboardEvent("keydown", {
+      bubbles: true,
+      cancelable: true,
+      key: "Enter",
+      code: "Enter",
+      ctrlKey: false,
+      metaKey: false,
+      shiftKey: true
+    });
+    event.target.dispatchEvent(newEvent);
+  }
+}
+
+// This event handler should always be registered because it must be registered before event handlers of Claude
+document.addEventListener("keydown", handleCtrlEnter, { capture: true });
+
+chrome.storage.sync.get("isEnabled", (data) => {
+  const isEnabled = data.isEnabled !== undefined ? data.isEnabled : true;
+  isHandleCtrlEnterEnabled = isEnabled;
+});
+
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area === "sync" && "isEnabled" in changes) {
+    const isEnabled = changes.isEnabled.newValue;
+    isHandleCtrlEnterEnabled = isEnabled;
+  }
+});


### PR DESCRIPTION
[Claude](https://claude.ai)でもこの拡張機能を利用できるように

## 実装内容

### Claude用に新たなContent Scriptを作成
他サイトと実行タイミングが異なるため，新たなスクリプトファイルを作成

サイトのJavascriptが読み込まれる前に，以下の処理を行う
- 処理対象：`contenteditable`属性が`true`であるdiv
- 処理内容：keydownイベントを監視し，Enterキー単体の入力イベントをShift+Enterのイベントへと置換する

### popup.jsやbackground.jsのClaude対応

Close #38 