### PR TITLE
Bugfix linebreak

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -16,7 +16,12 @@
     {
       "matches": [
         "https://chat.openai.com/*",
-        "https://chatgpt.com/*",
+        "https://chatgpt.com/*"
+      ],
+      "js": ["script_chatgpt.js"]
+    },
+    {
+      "matches": [
         "https://poe.com/*",
         "https://www.phind.com/*",
         "https://chat.mistral.ai/*",

--- a/script.js
+++ b/script.js
@@ -1,5 +1,5 @@
 function handleCtrlEnter(event) {
-  if (!event.target.tagName === "TEXTAREA") {
+  if (event.target.tagName !== "TEXTAREA") {
     return;
   }
 

--- a/script_chatgpt.js
+++ b/script_chatgpt.js
@@ -8,8 +8,8 @@ function handleCtrlEnter(event) {
 
   if (isOnlyEnter) {
     event.preventDefault();
-    let newEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
+    let newEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
       shiftKey: true,
       bubbles: true,
       cancelable: true
@@ -19,10 +19,13 @@ function handleCtrlEnter(event) {
     // Dispatch event only on Windows
     // Use metaKey on Windows to enable editing confirmation on the ChatGPT page, similar to Mac
     event.preventDefault();
-    let newEvent = new KeyboardEvent('keydown', {
-      key: 'Enter',
+    let newEvent = new KeyboardEvent("keydown", {
       bubbles: true,
-      cancelable: true
+      cancelable: true,
+      key: "Enter",
+      code: "Enter",
+      ctrlKey: false,
+      metaKey: true,
     });
     event.target.dispatchEvent(newEvent);
   }

--- a/script_chatgpt.js
+++ b/script_chatgpt.js
@@ -1,13 +1,30 @@
 function handleCtrlEnter(event) {
-  if (event.target.tagName !== "TEXTAREA") {
+  if (event.target.id !== "prompt-textarea") {
     return;
   }
 
   const isOnlyEnter = event.code == "Enter" && !(event.ctrlKey || event.metaKey);
+  const isCtrlEnter = event.code == "Enter" && event.ctrlKey;
 
   if (isOnlyEnter) {
-    // stopPropagation for both Windows and Mac
-    event.stopPropagation();
+    event.preventDefault();
+    let newEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      shiftKey: true,
+      bubbles: true,
+      cancelable: true
+    });
+    event.target.dispatchEvent(newEvent);
+  } else if (isCtrlEnter) {
+    // Dispatch event only on Windows
+    // Use metaKey on Windows to enable editing confirmation on the ChatGPT page, similar to Mac
+    event.preventDefault();
+    let newEvent = new KeyboardEvent('keydown', {
+      key: 'Enter',
+      bubbles: true,
+      cancelable: true
+    });
+    event.target.dispatchEvent(newEvent);
   }
 }
 

--- a/zip.py
+++ b/zip.py
@@ -42,6 +42,7 @@ def main():
         "popup.js",
         "script.js",
         "script_document_start.js"
+        "script_chatgpt.js"
     ]
     create_zip(".", "extension.zip", include_items)
 


### PR DESCRIPTION
close https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/issues/54

## Summary

This issue, where line breaks were not working as expected in ChatGPT when using this extension, has been resolved.

## Cause of the Issue

ChatGPT's chat input field was changed from using the `textarea` tag to using a `div` tag. The use of `event.stopPropagation();` was insufficient for controlling the event, so I handled it using `dispatchEvent`.

## Additional Notes

To avoid affecting anything other than ChatGPT, I separated the fix into a different script.

Additionally, I made the following fixes:

- Corrected the condition in the first `handleCtrlEnter` conditional branch as it was incorrect.

---

Please note that this has only been tested in a Windows & Chrome environment, so I would appreciate it if you could verify its functionality on other platforms as well.
