### PR TITLE
Add support for copilot.microsoft.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ You can use this extension on the following pages:
 * <https://chat.deepseek.com>
 * <https://github.com>
 * <https://grok.com>
+* <https://copilot.microsoft.com>
 
 ## Demo Video
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -38,6 +38,7 @@
 * <https://chat.deepseek.com>
 * <https://github.com>
 * <https://grok.com>
+* <https://copilot.microsoft.com>
 
 ## 演示视频
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -38,6 +38,7 @@
 * <https://chat.deepseek.com>
 * <https://github.com>
 * <https://grok.com>
+* <https://copilot.microsoft.com>
 
 ## デモ動画
 

--- a/background.js
+++ b/background.js
@@ -14,7 +14,8 @@ chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
                 url.startsWith("https://you.com") ||
                 url.startsWith("https://v0.dev") ||
                 url.startsWith("https://chat.deepseek.com") ||
-                url.startsWith("https://dashboard.cohere.com/playground/chat"))) {
+                url.startsWith("https://dashboard.cohere.com/playground/chat") ||
+                url.startsWith("https://copilot.microsoft.com"))) {
         if (changeInfo.status === "complete") {
           chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
           chrome.action.enable(tabId);

--- a/manifest.json
+++ b/manifest.json
@@ -26,7 +26,8 @@
         "https://www.perplexity.ai/*",
         "https://you.com/*",
         "https://v0.dev/*",
-        "https://dashboard.cohere.com/playground/chat"
+        "https://dashboard.cohere.com/playground/chat",
+        "https://copilot.microsoft.com/*"
       ],
       "js": ["ctrl_enter_textarea.js"],
       "run_at": "document_start"

--- a/popup.js
+++ b/popup.js
@@ -28,7 +28,8 @@ function updateIcon() {
         url.startsWith("https://you.com") ||
         url.startsWith("https://v0.dev") ||
         url.startsWith("https://chat.deepseek.com") ||
-        url.startsWith("https://dashboard.cohere.com/playground/chat")) {
+        url.startsWith("https://dashboard.cohere.com/playground/chat") ||
+        url.startsWith("https://copilot.microsoft.com")) {
       chrome.action.setIcon({ path: isEnabled ? "icon/enabled.png" : "icon/disabled.png" });
     }
   });


### PR DESCRIPTION
## Added support for [copilot.microsoft.com](https://copilot.microsoft.com)

#73 

I've confirmed the following behaviour on macOS:

key | behaviour
--- | ---
Enter | line break
Cmd + Enter | submit
Ctrl + Enter | submit
Shift + Enter | line break

on these pages:

- `https://copilot.microsoft.com/`
- `https://copilot.microsoft.com/chats/<hash>`
