### PR TITLE
[update] allow submitting edits on Windows

### DIFF
--- a/ctrl_enter_chatgpt.js
+++ b/ctrl_enter_chatgpt.js
@@ -1,20 +1,37 @@
 function handleCtrlEnter(event) {
-  if (event.target.id !== "prompt-textarea" || !event.isTrusted) {
-    return;
-  }
-
   const isOnlyEnter = (event.code === "Enter") && !(event.ctrlKey || event.metaKey);
 
-  if (isOnlyEnter) {
+  // Ignore untrusted events
+  if (!event.isTrusted) return;
+
+  if (event.target.id === "prompt-textarea" && isOnlyEnter) {
     event.preventDefault();
-    let newEvent = new KeyboardEvent("keydown", {
+    const newEvent = new KeyboardEvent("keydown", {
       key: "Enter",
       code: "Enter",
       bubbles: true,
       cancelable: true,
       ctrlKey: false,
       metaKey: false,
-      shiftKey: isOnlyEnter
+      shiftKey: true,  // Simulate Shift+Enter to insert a line break
+    });
+    event.target.dispatchEvent(newEvent);
+  }
+
+  // On macOS, users can submit edits using the Meta key (Command key)
+  // To allow submitting edits on Windows, convert Ctrl to Meta
+  const isCtrlEnter = (event.code === "Enter") && event.ctrlKey;
+
+  if (event.target.tagName === "TEXTAREA" && isCtrlEnter) {
+    event.preventDefault();
+    const newEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      code: "Enter",
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: false,
+      metaKey: true,  // Simulate Meta+Enter to trigger submit on Windows as well
+      shiftKey: false,
     });
     event.target.dispatchEvent(newEvent);
   }


### PR DESCRIPTION
When editing a previously sent message like the one below, you need to click the send button to submit it on Windows. 
On Mac, however, you can submit it by pressing Command + Enter without clicking the button. 
To make the experience similar on Windows, we’ve added support for sending messages with Ctrl + Enter as well.
![image](https://github.com/user-attachments/assets/7ed5be76-ffb3-4967-8cca-cd7060a3149a)
