### PR TITLE
Fix: Restore Ctrl+Enter submission in ChatGPT sidebar view by simulating Meta+Enter

### DIFF
--- a/ctrl_enter_chatgpt.js
+++ b/ctrl_enter_chatgpt.js
@@ -1,10 +1,12 @@
 function handleCtrlEnter(event) {
   const isOnlyEnter = (event.code === "Enter") && !(event.ctrlKey || event.metaKey);
+  const isCtrlEnter = (event.code === "Enter") && event.ctrlKey;
 
   // Ignore untrusted events
   if (!event.isTrusted) return;
 
-  if (event.target.id === "prompt-textarea" && isOnlyEnter) {
+  // Specific handling for ChatGPT's prompt textarea
+  if (event.target.id === "prompt-textarea" && (isOnlyEnter || isCtrlEnter)) {
     event.preventDefault();
     const newEvent = new KeyboardEvent("keydown", {
       key: "Enter",
@@ -12,17 +14,15 @@ function handleCtrlEnter(event) {
       bubbles: true,
       cancelable: true,
       ctrlKey: false,
-      metaKey: false,
-      shiftKey: true,  // Simulate Shift+Enter to insert a line break
+      metaKey: isCtrlEnter,  // ChatGPT UI ignores Ctrl+Enter in narrow (mobile/sidebar) view; simulate Meta+Enter instead to ensure submission
+      shiftKey: isOnlyEnter,  // Simulate Shift+Enter to insert a line break
     });
     event.target.dispatchEvent(newEvent);
   }
 
   // On macOS, users can submit edits using the Meta key (Command key)
   // To allow submitting edits on Windows, convert Ctrl to Meta
-  const isCtrlEnter = (event.code === "Enter") && event.ctrlKey;
-
-  if (event.target.tagName === "TEXTAREA" && isCtrlEnter) {
+  else if (event.target.tagName === "TEXTAREA" && isCtrlEnter) {
     event.preventDefault();
     const newEvent = new KeyboardEvent("keydown", {
       key: "Enter",

--- a/ctrl_enter_chatgpt.js
+++ b/ctrl_enter_chatgpt.js
@@ -1,12 +1,13 @@
 function handleCtrlEnter(event) {
   const isOnlyEnter = (event.code === "Enter") && !(event.ctrlKey || event.metaKey);
   const isCtrlEnter = (event.code === "Enter") && event.ctrlKey;
+  const isPromptTextarea = event.target.id === "prompt-textarea";
 
   // Ignore untrusted events
   if (!event.isTrusted) return;
 
   // Specific handling for ChatGPT's prompt textarea
-  if (event.target.id === "prompt-textarea" && (isOnlyEnter || isCtrlEnter)) {
+  if (isPromptTextarea && isOnlyEnter) {
     event.preventDefault();
     const newEvent = new KeyboardEvent("keydown", {
       key: "Enter",
@@ -14,8 +15,21 @@ function handleCtrlEnter(event) {
       bubbles: true,
       cancelable: true,
       ctrlKey: false,
-      metaKey: isCtrlEnter,  // ChatGPT UI ignores Ctrl+Enter in narrow (mobile/sidebar) view; simulate Meta+Enter instead to ensure submission
-      shiftKey: isOnlyEnter,  // Simulate Shift+Enter to insert a line break
+      metaKey: false,
+      shiftKey: true,  // Simulate Shift+Enter to insert a line break
+    });
+    event.target.dispatchEvent(newEvent);
+  }
+  else if (isPromptTextarea && isCtrlEnter) {
+    event.preventDefault();
+    const newEvent = new KeyboardEvent("keydown", {
+      key: "Enter",
+      code: "Enter",
+      bubbles: true,
+      cancelable: true,
+      ctrlKey: false,
+      metaKey: true,  // ChatGPT UI ignores Ctrl+Enter in narrow (mobile/sidebar) view; simulate Meta+Enter instead to ensure submission
+      shiftKey: false,
     });
     event.target.dispatchEvent(newEvent);
   }


### PR DESCRIPTION
### Summary

This PR fixes an issue where pressing `Ctrl+Enter` fails to submit messages in ChatGPT's sidebar (narrow/mobile) view, such as when using the Opera browser sidebar.

In narrow layouts, the ChatGPT UI does not respond to `Ctrl+Enter` events. However, it still responds to `Meta+Enter`. Previously, this extension simulated `Meta+Enter` when `Ctrl+Enter` was detected to ensure consistent behavior — but that logic was removed in a recent update, causing a regression.

### Fix Details

- When `Ctrl+Enter` is detected on the `#prompt-textarea`, this patch dispatches a new `KeyboardEvent` with `metaKey: true`.
- This ensures that message submission works even in sidebar/mobile view.
- The event is only dispatched when the original event is trusted (`event.isTrusted`).

### Related Issue

Closes #81 