### PR TITLE
Fix: GeminiでShift+Enterすると挙動がおかしい＆編集モードで機能しない

### DIFF
--- a/content/ctrl-enter-custom-inputs.js
+++ b/content/ctrl-enter-custom-inputs.js
@@ -6,10 +6,15 @@ function shouldHandleCtrlEnter(url, event) {
     return event.target.tagName === "TEXTAREA" && event.target.classList.contains("query-box-input");
   }
   else if (url.startsWith("https://gemini.google.com")) {
-    return event.target.tagName === "DIV" &&
-           event.target.classList.contains("ql-editor") &&
-           event.target.contentEditable === "true" &&
-           !(event.shiftKey && event.code === "Enter");
+    return (
+      (
+        event.target.tagName === "DIV" &&
+        event.target.classList.contains("ql-editor") &&
+        event.target.contentEditable === "true"
+      ) || (
+        event.target.tagName === "TEXTAREA"
+      )) &&
+      !(event.shiftKey && event.code === "Enter");
   }
   else if (url.startsWith("https://www.phind.com")) {
     return event.target.tagName === "DIV" &&


### PR DESCRIPTION
## 概要
Geminiに関連する２つのバグを修正しました

### Shift+Enterで改行すると改行後の入力挙動がおかしくなる
Shift+Enterで改行した後、日本語で入力しようとすると最初のキーだけ`ｋお`のようにそのまま入力されてしまう
<img width="322" height="156" alt="image" src="https://github.com/user-attachments/assets/25651686-1716-4cd7-b3e2-0b0b92d33111" />

（Google AI Proプラン、Windows+Chrome、MacOS+Chromeで発生を確認）

### 編集モードで動作しない
編集モードでEnterを押すとそのまま送信されてしまう

---

## 変更点
shouldHandleCtrlEnter関数の条件を変更し、"Shift+Enter"の入力時にハンドルしないようにしました
また、編集モードに対応するため`TEXTAREA`の場合もハンドルするようにしました

Windows11+Chrome環境でテストしています