### PR TITLE
Add support for Rakuten AI (ai.rakuten.co.jp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ You can use this extension on the following pages:
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
+* <https://ai.rakuten.co.jp>
 
 ## Demo Video
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -39,6 +39,7 @@
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
+* <https://ai.rakuten.co.jp>
 
 ## 演示视频
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -39,6 +39,7 @@
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
+* <https://ai.rakuten.co.jp>
 
 ## デモ動画
 

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -22,6 +22,7 @@ export const SITE_CONFIGS = [
   { hostname: "poe.com", matchPatterns: ["https://poe.com/*"] },
   { hostname: "v0.app", matchPatterns: ["https://v0.app/*"] },
   { hostname: "cursor.com", matchPatterns: ["https://cursor.com/agents*", "https://cursor.com/*/agents*"] },
+  { hostname: "ai.rakuten.co.jp", matchPatterns: ["https://ai.rakuten.co.jp/*"] },
 ];
 
 export const SUPPORTED_SITES = SITE_CONFIGS.map((c) => c.hostname);

--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -275,6 +275,20 @@ const SITE_BEHAVIORS = {
     },
   },
 
+  "ai.rakuten.co.jp": {
+    shouldHandle(event) {
+      return event.target.tagName === "TEXTAREA";
+    },
+    onEnter(event) {
+      event.stopImmediatePropagation();
+      dispatchEnter(event.target, { shiftKey: true });
+    },
+    onCtrlEnter(event) {
+      event.stopImmediatePropagation();
+      dispatchEnter(event.target, {});
+    },
+  },
+
   "cursor.com": {
     shouldHandle(event) {
       const url = window.location.href;

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,8 @@
         "https://poe.com/*",
         "https://v0.app/*",
         "https://cursor.com/agents*",
-        "https://cursor.com/*/agents*"
+        "https://cursor.com/*/agents*",
+        "https://ai.rakuten.co.jp/*"
       ],
       "js": [
         "content/ctrl-enter-utils.js",
@@ -59,7 +60,8 @@
     "https://grok.com/*",
     "https://copilot.microsoft.com/*",
     "https://m365.cloud.microsoft/*",
-    "https://cursor.com/*"
+    "https://cursor.com/*",
+    "https://ai.rakuten.co.jp/*"
   ],
   "action": {
     "default_popup": "popup/popup.html",

--- a/tests/site-definitions.js
+++ b/tests/site-definitions.js
@@ -99,6 +99,14 @@ const SITES = [
     requiresAuth: true,
     notes: "Lexical editor。サブスクリプション必要",
   },
+  {
+    name: "Rakuten AI",
+    url: "https://ai.rakuten.co.jp/",
+    inputSelector: "textarea",
+    inputType: "textarea",
+    requiresAuth: false,
+    notes: "Enter→送信（デフォルト）。Shift+Enter→改行。認証不要でチャット可能",
+  },
 ];
 
 module.exports = { SITES };


### PR DESCRIPTION
Closes #120

## Summary
- Add Ctrl+Enter to send support for Rakuten AI (https://ai.rakuten.co.jp)
- Enter now inserts a newline instead of sending
- Ctrl+Enter sends the message

## Changes
- `constants/site-configs.js` — add hostname and matchPatterns
- `content/ctrl-enter-handler.js` — add behavior (Tier 3)
- `manifest.json` — add to content_scripts matches and host_permissions
- `tests/site-definitions.js` — add site definition
- README files (en/ja/zh) — add to supported sites list

## Site Details
- Input element: plain `<textarea>` (no id, no class, placeholder: "Input message here")
- Default behavior: Enter sends, Shift+Enter inserts newline
- Implementation: intercept Enter → dispatch Shift+Enter (newline); intercept Ctrl+Enter → dispatch Enter (submit)

## Test Plan
- [x] Loaded unpacked extension on macOS / Chrome
- [x] Navigated to https://ai.rakuten.co.jp
- [x] Enter → newline inserted, message NOT sent
- [x] Ctrl+Enter → message sent
- [x] `python tools/check_supported_sites.py` passes with no diff
