### PR TITLE
Security hardening: scope button queries and reduce host_permissions

### DIFF
--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -89,7 +89,8 @@ const SITE_BEHAVIORS = {
       dispatchEnter(event.target, {});
       // Claude edit mode: TEXTAREA needs button click to submit
       if (event.target.tagName === "TEXTAREA") {
-        const saveButton = document.querySelector('button[type="submit"]');
+        const container = event.target.closest('form') || event.target.parentElement;
+        const saveButton = container?.querySelector('button[type="submit"]');
         if (saveButton) saveButton.click();
       }
     },
@@ -302,8 +303,10 @@ const SITE_BEHAVIORS = {
 
 // ── Unified handler ──────────────────────────────────────────────────────────
 
+let _handling = false;
+
 function handleCtrlEnter(event) {
-  if (event.isComposing || !event.isTrusted) return;
+  if (_handling || event.isComposing || !event.isTrusted) return;
   if (!isEnterKey(event)) return;
 
   const hostname = window.location.hostname;
@@ -313,10 +316,15 @@ function handleCtrlEnter(event) {
   const isOnlyEnter = !event.ctrlKey && !event.metaKey;
   const isCtrlEnter = event.ctrlKey || event.metaKey;
 
-  if (isOnlyEnter && behavior.onEnter) {
-    behavior.onEnter(event);
-  } else if (isCtrlEnter && behavior.onCtrlEnter) {
-    behavior.onCtrlEnter(event);
+  _handling = true;
+  try {
+    if (isOnlyEnter && behavior.onEnter) {
+      behavior.onEnter(event);
+    } else if (isCtrlEnter && behavior.onCtrlEnter) {
+      behavior.onCtrlEnter(event);
+    }
+  } finally {
+    _handling = false;
   }
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -59,7 +59,8 @@
     "https://grok.com/*",
     "https://copilot.microsoft.com/*",
     "https://m365.cloud.microsoft/*",
-    "https://cursor.com/*"
+    "https://cursor.com/agents*",
+    "https://cursor.com/*/agents*"
   ],
   "action": {
     "default_popup": "popup/popup.html",


### PR DESCRIPTION
Closes #122

## Summary

- Scope Claude's `document.querySelector('button[type="submit"]')` to the input's nearest `form` or parent element, preventing page-wide button injection attacks
- Narrow `host_permissions` for cursor.com from `/*` to `/agents*` paths only (matching `content_scripts`)
- Add reentrancy guard (`_handling` flag) to `handleCtrlEnter` as defense-in-depth

## Details

### Button query scoping (High)

Before: `document.querySelector('button[type="submit"]')` — searches entire page
After: `event.target.closest('form')?.querySelector(...)` — searches only the input's container

Other sites already have proper scoping:
- Cursor: uses `findFormButton` (`closest("form")`)
- NotebookLM: uses `query-box form` (custom element scope)

### host_permissions (Medium)

Before: `"https://cursor.com/*"`
After: `"https://cursor.com/agents*"` + `"https://cursor.com/*/agents*"`

Matches the `content_scripts.matches` patterns exactly.

### Reentrancy guard (Low)

Adds a `_handling` flag alongside the existing `isTrusted` check to prevent recursive event dispatch even if browser behavior changes in the future.

## Test Plan

- [x] `node tools/ctrl-enter-handler.test.js` — 13/13 pass
- [x] `python tools/check_supported_sites.py` — no diff
- [ ] Manual: load unpacked extension in Chrome, verify Ctrl+Enter on claude.ai
