### PR TITLE
feat: restore Firefox 128+ support via MV3 browser_specific_settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,4 +52,6 @@ Bug reports for Tier 1 and Tier 2 sites are always welcome. Please use the issue
 
 ## Firefox
 
-**Firefox support has been discontinued.** The maintainer does not use Firefox and the Firefox extension platform has significant differences (MV3 migration, etc.), making continued maintenance difficult. The Firefox branch contains the last available version.
+Firefox 128+ is supported via the same Manifest V3 codebase as Chrome. The `browser_specific_settings.gecko` key in `manifest.json` enables Firefox compatibility. No separate Firefox branch is needed.
+
+Bug reports for Firefox are welcome. Please note the Firefox version in your report.

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ English | [日本語](README_JA.md) | [简体中文](README_CH.md)
 ### Chromium-based Browsers (e.g. Chrome, Edge, Brave, etc.)
 [Available on Chrome Web Store](https://chrome.google.com/webstore/detail/chatgpt-ctrl%20enter-sender/gbncgdhklmnckojlibfhdadpfbcdbnch)
 
-### Firefox
-[Firefox Add-on page](https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/tree/firefox)
+### Firefox (128+)
+Firefox is supported via the same codebase as Chrome (Manifest V3).
 
-> **Note:** The Firefox version is not currently being updated as the maintainer is unable to dedicate time to it. The link above is the last available version.
+To install manually until a Firefox Add-on page is available:
+1. Download or clone this repository
+2. Open `about:debugging` in Firefox → **This Firefox** → **Load Temporary Add-on**
+3. Select `manifest.json` from the repository folder
 
 ## Features
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -12,10 +12,13 @@
 ### 基于Chromium的浏览器 (例如：Chrome、Edge、Brave 等等)
 [在 Chrome 网上应用店中可用](https://chrome.google.com/webstore/detail/chatgpt-ctrl%20enter-sender/gbncgdhklmnckojlibfhdadpfbcdbnch)
 
-### Firefox
-[Firefox 扩展页面](https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/tree/firefox)
+### Firefox（128及以上）
+Firefox 通过与 Chrome 相同的代码库（Manifest V3）得到支持。
 
-> **注意:** 由于维护者无法投入精力维护Firefox版本，目前已停止更新。以上链接为最后的版本。
+在 Firefox 扩展页面上架之前，请按以下步骤手动安装：
+1. 下载或克隆本仓库
+2. 在 Firefox 中打开 `about:debugging` → **此 Firefox** → **临时载入附加组件**
+3. 选择仓库文件夹中的 `manifest.json`
 
 ## 功能
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -12,10 +12,13 @@
 ### Chromium ベースのブラウザ (例: Chrome, Edge, Brave など)
 [Chrome ウェブストアで利用可能](https://chrome.google.com/webstore/detail/chatgpt-ctrl%20enter-sender/gbncgdhklmnckojlibfhdadpfbcdbnch)
 
-### Firefox
-[Firefox アドオンページ](https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/tree/firefox)
+### Firefox (128以降)
+Chrome と同じコードベース（Manifest V3）で Firefox に対応しています。
 
-> **注意:** メンテナがFirefox版に注力できていないため、現在更新を停止しています。上記リンクは最後のバージョンとなります。
+Firefox アドオンページが公開されるまでの手動インストール手順：
+1. このリポジトリをダウンロードまたはクローンする
+2. Firefox で `about:debugging` を開く → **この Firefox** → **一時的なアドオンを読み込む**
+3. リポジトリフォルダ内の `manifest.json` を選択する
 
 ## 機能
 

--- a/manifest.json
+++ b/manifest.json
@@ -16,6 +16,7 @@
   ],
   "background": {
     "service_worker": "background.js",
+    "scripts": ["background.js"],
     "type": "module"
   },
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -5,6 +5,12 @@
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "chatgpt-ctrl-enter-sender@chatgpt-extension.io",
+      "strict_min_version": "128.0"
+    }
+  },
   "permissions": [
     "storage"
   ],


### PR DESCRIPTION
Closes #124

## Summary

- Add `browser_specific_settings.gecko` with `strict_min_version: "128.0"` to declare Firefox 128+ compatibility
- Add `background.scripts` alongside `service_worker` for cross-browser MV3 compatibility
- Update README/CONTRIBUTING to replace the discontinued Firefox notice with install instructions

## How It Works

Firefox 128+ supports Manifest V3 `background.service_worker` with `type: module`, which means the existing codebase runs unchanged on Firefox. No separate code path is needed.

| Component | Firefox support |
|-----------|----------------|
| `background.service_worker` + `type: module` | Firefox 128+ |
| `chrome.*` APIs | Aliased to `browser.*` automatically |
| `<script type="module">` in popup/options | All modern Firefox |
| `content_scripts` (classic scripts) | All versions |

## Why `strict_min_version: "128.0"`

Firefox < 128 does not support MV3 service workers. Setting the minimum version ensures users on unsupported versions see a clear "incompatible" message from Firefox rather than a cryptic runtime error.

## Test Plan

- [ ] Load unpacked extension in Firefox 128+ via `about:debugging#/runtime/this-firefox`
- [ ] Verify background service worker loads without error
- [ ] Verify Ctrl+Enter sends on ChatGPT / Claude
- [ ] Verify popup toggle works
- [ ] Extension installs cleanly on Chrome (no regression)
