### PR TITLE
chore(security): add SECURITY.md and least-privilege workflow permissions

### DIFF
--- a/.github/workflows/check-supported-sites.yml
+++ b/.github/workflows/check-supported-sites.yml
@@ -16,6 +16,9 @@ on:
       - 'README*.md'
       - 'tools/check_supported_sites.py'
 
+permissions:
+  contents: read
+
 jobs:
   check-supported-sites:
     runs-on: ubuntu-latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Supported Versions
+
+Only the **latest released version** of this extension published on the Chrome Web Store receives security updates. Older versions are not maintained.
+
+## Reporting a Vulnerability
+
+Please **do not** report security vulnerabilities through public GitHub issues, discussions, or pull requests.
+
+Instead, use GitHub's **Private vulnerability reporting** feature:
+
+1. Go to the [Security tab](https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/security) of this repository
+2. Click **Report a vulnerability**
+3. Fill in the form with as much detail as possible (affected version, steps to reproduce, potential impact)
+
+You can expect:
+
+- An acknowledgement within **7 days**
+- A status update within **30 days**
+- Coordinated disclosure once a fix is released to the Chrome Web Store
+
+Thank you for helping keep this project and its users safe.


### PR DESCRIPTION
## 概要

セキュリティハードニングの一環として2つの変更を加えます。

## 変更点

### 1. `.github/workflows/check-supported-sites.yml`
- `permissions: contents: read` を明示
- CodeQL の `actions/missing-workflow-permissions` 警告に対応
- workflow が GITHUB_TOKEN の最小権限のみ使用することを保証

### 2. `SECURITY.md` (新規)
- 脆弱性報告窓口を明文化 (GitHub Private vulnerability reporting に誘導)
- サポート対象は最新版のみと明記