### PR TITLE
fix(copilot): use stopImmediatePropagation for consistency with other sites

### DIFF
--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -121,7 +121,7 @@ const SITE_BEHAVIORS = {
       return event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
-      event.stopPropagation();
+      event.stopImmediatePropagation();
     },
   },
 

--- a/tools/ctrl-enter-handler.test.js
+++ b/tools/ctrl-enter-handler.test.js
@@ -242,6 +242,28 @@ test("Poe の TEXTAREA で Ctrl+Enter はパススルー", () => {
   assert.equal(event.preventDefaultCount, 0);
 });
 
+test("Copilot の TEXTAREA で Enter は stopImmediatePropagation のみ", () => {
+  const context = loadHandler("https://copilot.microsoft.com/", createButton());
+  const event = createKeydownEvent({ tagName: "TEXTAREA" });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.stopImmediatePropagationCount, 1);
+  assert.equal(event.stopPropagationCount, 0);
+  assert.equal(event.preventDefaultCount, 0);
+});
+
+test("Copilot の TEXTAREA で Ctrl+Enter はパススルー", () => {
+  const context = loadHandler("https://copilot.microsoft.com/", createButton());
+  const event = createKeydownEvent({ tagName: "TEXTAREA" }, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.stopImmediatePropagationCount, 0);
+  assert.equal(event.stopPropagationCount, 0);
+  assert.equal(event.preventDefaultCount, 0);
+});
+
 // ── ChatGPT tests ────────────────────────────────────────────────────────────
 
 test("ChatGPT の prompt-textarea で Enter は Shift+Enter にマッピング", () => {


### PR DESCRIPTION
Refs #128

## Summary

Aligned the Copilot handler with other sites (Claude / Gemini / M365 etc.) by replacing `stopPropagation()` with `stopImmediatePropagation()`.

## Why

`stopPropagation` only stops the event from bubbling to parent elements; it does **not** stop other listeners registered on the same element. If Copilot attaches its Enter-to-send listener directly on the input element, `stopPropagation` alone can leak depending on listener registration order, which is a plausible cause of the "sometimes Enter still sends" symptom reported in #128. `stopImmediatePropagation` is a functional superset of `stopPropagation` with effectively no downside.

## Changes

- `content/ctrl-enter-handler.js`: updated the `copilot.microsoft.com` handler.
- `tools/ctrl-enter-handler.test.js`: added unit tests for Copilot (Enter / Ctrl+Enter).