### PR TITLE
feat: optional host permissions for new and niche sites

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,6 +21,21 @@ These sites are supported but maintained on a best-effort basis:
 These sites may be removed if they become unmaintainable:
 - Poe, v0, Cursor, Genspark, duck.ai, Manus
 
+## How New Sites Are Shipped (Opt-in)
+
+Adding a site to the manifest's required permissions disables the extension
+for every existing user until they re-approve it. To avoid this, all new
+sites are added as **opt-in** sites:
+
+- They are listed in `optional_host_permissions` (never in `host_permissions`
+  or static `content_scripts`).
+- They are marked `optional: true` in `constants/site-configs.js`.
+- Users enable them once per site via the popup ("Enable on this site").
+- `tests/permission-warnings.spec.js` enforces in CI that no change introduces
+  a new permission warning.
+
+See the checklist in `constants/site-configs.js` for the exact steps.
+
 ## New Site Requests
 
 We consider new site support under these criteria:

--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ You can use this extension on the following pages:
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
-* <https://www.genspark.ai>
-* <https://duck.ai>
-* <https://manus.im>
+* <https://www.genspark.ai> (opt-in)
+* <https://duck.ai> (opt-in)
+* <https://manus.im> (opt-in)
+
+*Opt-in sites: to keep updates from requiring new permissions for everyone, these sites are enabled per user. Open the site, click the extension icon, and press "Enable on this site" once.*
 
 ## Demo Video
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ You can use this extension on the following pages:
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://cursor.com/agents>
+* <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)

--- a/README_CH.md
+++ b/README_CH.md
@@ -39,9 +39,11 @@
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
-* <https://www.genspark.ai>
-* <https://duck.ai>
-* <https://manus.im>
+* <https://www.genspark.ai> (opt-in)
+* <https://duck.ai> (opt-in)
+* <https://manus.im> (opt-in)
+
+*可选站点: 为避免更新时要求所有用户重新授权，这些站点需按用户启用。打开站点，点击扩展图标，然后按一次 "Enable on this site"。*
 
 ## 演示视频
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -38,7 +38,7 @@
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://cursor.com/agents>
+* <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)

--- a/README_JA.md
+++ b/README_JA.md
@@ -38,7 +38,7 @@
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://cursor.com/agents>
+* <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)

--- a/README_JA.md
+++ b/README_JA.md
@@ -39,9 +39,11 @@
 * <https://poe.com>
 * <https://v0.app>
 * <https://cursor.com/agents>
-* <https://www.genspark.ai>
-* <https://duck.ai>
-* <https://manus.im>
+* <https://www.genspark.ai> (opt-in)
+* <https://duck.ai> (opt-in)
+* <https://manus.im> (opt-in)
+
+*オプトイン サイト: 全ユーザーへの権限再承認を避けるため、これらのサイトはユーザーごとに有効化する方式です。サイトを開いて拡張機能のアイコンをクリックし、「Enable on this site」を一度押してください。*
 
 ## デモ動画
 

--- a/background.js
+++ b/background.js
@@ -42,7 +42,11 @@ async function ensureActionRules() {
 // Optional sites are not in manifest content_scripts; their scripts are
 // registered here once the user grants the host permission (see popup).
 
+let _syncing = false;
 async function syncOptionalContentScripts() {
+  if (_syncing) return;
+  _syncing = true;
+  try {
   const registered = await chrome.scripting.getRegisteredContentScripts();
   const registeredIds = new Set(registered.map((script) => script.id));
 
@@ -60,6 +64,9 @@ async function syncOptionalContentScripts() {
     } else if (!granted && registeredIds.has(config.hostname)) {
       await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
     }
+  }
+  } finally {
+    _syncing = false;
   }
 }
 

--- a/background.js
+++ b/background.js
@@ -1,4 +1,73 @@
-import { SUPPORTED_SITES, extractHostname } from "./constants/site-configs.js";
+import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS, SUPPORTED_SITES, extractHostname } from "./constants/site-configs.js";
+
+// ── Action icon visibility ───────────────────────────────────────────────────
+// The action is disabled by default and shown declaratively on supported sites.
+// declarativeContent needs no host access, so the icon stays clickable on
+// optional sites even before the user grants the host permission (the popup is
+// where they grant it).
+
+function matchPatternToRegex(pattern) {
+  return "^" + pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$";
+}
+
+const ACTION_RULE_REGEXES = SITE_CONFIGS.flatMap((config) => config.matchPatterns.map(matchPatternToRegex));
+
+function getActionRules() {
+  return new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
+}
+
+async function ensureActionRules() {
+  chrome.action.disable();
+
+  const rules = await getActionRules();
+  const current = rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
+  const upToDate =
+    current.length === ACTION_RULE_REGEXES.length &&
+    ACTION_RULE_REGEXES.every((regex) => current.includes(regex));
+  if (upToDate) return;
+
+  chrome.declarativeContent.onPageChanged.removeRules(undefined, () => {
+    chrome.declarativeContent.onPageChanged.addRules([
+      {
+        conditions: ACTION_RULE_REGEXES.map(
+          (regex) => new chrome.declarativeContent.PageStateMatcher({ pageUrl: { urlMatches: regex } })
+        ),
+        actions: [new chrome.declarativeContent.ShowAction()],
+      },
+    ]);
+  });
+}
+
+// ── Dynamic content scripts for optional sites ───────────────────────────────
+// Optional sites are not in manifest content_scripts; their scripts are
+// registered here once the user grants the host permission (see popup).
+
+async function syncOptionalContentScripts() {
+  const registered = await chrome.scripting.getRegisteredContentScripts();
+  const registeredIds = new Set(registered.map((script) => script.id));
+
+  for (const config of OPTIONAL_SITE_CONFIGS) {
+    const granted = await chrome.permissions.contains({ origins: config.matchPatterns });
+    if (granted && !registeredIds.has(config.hostname)) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: config.hostname,
+          matches: config.matchPatterns,
+          js: ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"],
+          runAt: "document_start",
+        },
+      ]);
+    } else if (!granted && registeredIds.has(config.hostname)) {
+      await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
+    }
+  }
+}
+
+// Both operations are idempotent, so run them on every service worker start
+// rather than relying on onInstalled/onStartup (which don't cover all the
+// ways rules and registrations can get out of sync, e.g. unpacked loads).
+ensureActionRules();
+syncOptionalContentScripts();
 
 // Notify user on update (useful for non-host_permissions changes)
 chrome.runtime.onInstalled.addListener((details) => {
@@ -7,11 +76,29 @@ chrome.runtime.onInstalled.addListener((details) => {
   }
 });
 
-chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
-  const url = tab.url;
-  const hostname = extractHostname(url);
+// Covers grants/revocations from the popup, the options page, and the
+// site-access controls in chrome://extensions.
+chrome.permissions.onAdded.addListener(() => syncOptionalContentScripts());
+chrome.permissions.onRemoved.addListener(() => syncOptionalContentScripts());
 
-  if (!url || !SUPPORTED_SITES.includes(hostname)) {
+// Lets the popup/options page wait for registration before reloading the tab.
+chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
+  if (message?.type === "sync-optional-sites") {
+    syncOptionalContentScripts().then(() => sendResponse(true));
+    return true;
+  }
+});
+
+// ── Per-tab icon state on supported sites ────────────────────────────────────
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  // tab.url is unavailable on sites we have no host permission for
+  // (e.g. optional sites not yet granted); leave those to declarativeContent
+  const url = tab.url;
+  if (!url) return;
+
+  const hostname = extractHostname(url);
+  if (!SUPPORTED_SITES.includes(hostname)) {
     chrome.action.disable(tabId);
     return;
   }

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -30,7 +30,7 @@ export const SITE_CONFIGS = [
   { hostname: "github.com", matchPatterns: ["https://github.com/copilot*", "https://github.com/spark*"] },
   { hostname: "poe.com", matchPatterns: ["https://poe.com/*"] },
   { hostname: "v0.app", matchPatterns: ["https://v0.app/*"] },
-  { hostname: "cursor.com", matchPatterns: ["https://cursor.com/agents*", "https://cursor.com/*/agents*"] },
+  { hostname: "cursor.com", matchPatterns: ["https://cursor.com/agents*", "https://cursor.com/*/agents*"], optional: true },
   { hostname: "www.genspark.ai", matchPatterns: ["https://www.genspark.ai/*"], optional: true },
   { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"], optional: true },
   { hostname: "manus.im", matchPatterns: ["https://manus.im/*"], optional: true },

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -1,10 +1,19 @@
 /**
  * Central site configuration — single source of truth for all supported sites.
  *
+ * Sites come in two kinds:
+ *   - Required sites: listed in manifest.json content_scripts / host_permissions.
+ *     Adding one triggers a permission re-approval that disables the extension
+ *     for every user until they re-enable it. Do NOT add new required sites.
+ *   - Optional sites (`optional: true`): covered by optional_host_permissions.
+ *     The user grants access per-site from the popup; content scripts are
+ *     registered dynamically by background.js. Adding one never disables the
+ *     extension for existing users.
+ *
  * When adding a new site:
- *   1. Add an entry here (hostname + matchPatterns)
+ *   1. Add an entry here with `optional: true` (hostname + matchPatterns)
  *   2. Add behavior in content/ctrl-enter-handler.js
- *   3. Add match patterns to manifest.json content_scripts and host_permissions
+ *   3. Add the match patterns to optional_host_permissions in manifest.json
  *   4. Run `python tools/check_supported_sites.py` to verify consistency
  */
 export const SITE_CONFIGS = [
@@ -22,10 +31,12 @@ export const SITE_CONFIGS = [
   { hostname: "poe.com", matchPatterns: ["https://poe.com/*"] },
   { hostname: "v0.app", matchPatterns: ["https://v0.app/*"] },
   { hostname: "cursor.com", matchPatterns: ["https://cursor.com/agents*", "https://cursor.com/*/agents*"] },
-  { hostname: "www.genspark.ai", matchPatterns: ["https://www.genspark.ai/*"] },
-  { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"] },
-  { hostname: "manus.im", matchPatterns: ["https://manus.im/*"] },
+  { hostname: "www.genspark.ai", matchPatterns: ["https://www.genspark.ai/*"], optional: true },
+  { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"], optional: true },
+  { hostname: "manus.im", matchPatterns: ["https://manus.im/*"], optional: true },
 ];
+
+export const OPTIONAL_SITE_CONFIGS = SITE_CONFIGS.filter((c) => c.optional);
 
 export const SUPPORTED_SITES = SITE_CONFIGS.map((c) => c.hostname);
 

--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -72,7 +72,7 @@ const SITE_BEHAVIORS = {
   "claude.ai": {
     shouldHandle(event) {
       return (event.target.tagName === "DIV" && event.target.contentEditable === "true") ||
-             event.target.tagName === "TEXTAREA";
+        event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
       event.preventDefault();
@@ -129,7 +129,7 @@ const SITE_BEHAVIORS = {
     shouldHandle(event) {
       const url = window.location.href;
       return url.startsWith("https://m365.cloud.microsoft/chat") &&
-             event.target.id === "m365-chat-editor-target-element";
+        event.target.id === "m365-chat-editor-target-element";
     },
     onEnter(event) {
       event.preventDefault();
@@ -161,7 +161,7 @@ const SITE_BEHAVIORS = {
   "grok.com": {
     shouldHandle(event) {
       return event.target.tagName === "TEXTAREA" ||
-             (event.target.tagName === "DIV" && event.target.contentEditable === "true");
+        (event.target.tagName === "DIV" && event.target.contentEditable === "true");
     },
     onEnter(event) {
       event.stopImmediatePropagation();
@@ -192,9 +192,9 @@ const SITE_BEHAVIORS = {
   "chat.mistral.ai": {
     shouldHandle(event) {
       return (event.target.tagName === "DIV" &&
-              event.target.classList.contains("ProseMirror") &&
-              event.target.contentEditable === "true") ||
-             event.target.tagName === "TEXTAREA";
+        event.target.classList.contains("ProseMirror") &&
+        event.target.contentEditable === "true") ||
+        event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
       event.preventDefault();
@@ -228,7 +228,7 @@ const SITE_BEHAVIORS = {
     shouldHandle(event) {
       const url = window.location.href;
       return (url.startsWith("https://github.com/copilot") || url.startsWith("https://github.com/spark")) &&
-             event.target.tagName === "TEXTAREA";
+        event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
       event.stopImmediatePropagation();
@@ -254,9 +254,9 @@ const SITE_BEHAVIORS = {
   "v0.app": {
     shouldHandle(event) {
       return event.target.tagName === "TEXTAREA" ||
-             (event.target.tagName === "DIV" &&
-              event.target.classList.contains("ProseMirror") &&
-              event.target.contentEditable === "true");
+        (event.target.tagName === "DIV" &&
+          event.target.classList.contains("ProseMirror") &&
+          event.target.contentEditable === "true");
     },
     onEnter(event) {
       if (event.target.tagName === "TEXTAREA") {
@@ -281,10 +281,10 @@ const SITE_BEHAVIORS = {
     shouldHandle(event) {
       const url = window.location.href;
       return isCursorAgentsPath(url) &&
-             event.target.tagName === "DIV" &&
-             event.target.contentEditable === "true" &&
-             event.target.getAttribute("data-lexical-editor") === "true" &&
-             event.target.getAttribute("role") === "textbox";
+        event.target.tagName === "DIV" &&
+        event.target.contentEditable === "true" &&
+        event.target.getAttribute("data-lexical-editor") === "true" &&
+        event.target.getAttribute("role") === "textbox";
     },
     onEnter(event) {
       event.preventDefault();
@@ -306,7 +306,15 @@ const SITE_BEHAVIORS = {
       return event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
-      event.stopPropagation();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      insertTextareaNewline(event.target);
+    },
+    onCtrlEnter(event) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const button = document.querySelector(".enter-icon-wrapper");
+      if (button) button.click();
     },
   },
 
@@ -315,15 +323,23 @@ const SITE_BEHAVIORS = {
       return event.target.tagName === "TEXTAREA";
     },
     onEnter(event) {
-      event.stopPropagation();
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      insertTextareaNewline(event.target);
+    },
+    onCtrlEnter(event) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      const button = findFormButton(event.target, 'button[type="submit"]:not([disabled])');
+      if (button) button.click();
     },
   },
 
   "manus.im": {
     shouldHandle(event) {
       return event.target.tagName === "DIV" &&
-             event.target.classList.contains("ProseMirror") &&
-             event.target.contentEditable === "true";
+        event.target.classList.contains("ProseMirror") &&
+        event.target.contentEditable === "true";
     },
     onEnter(event) {
       event.preventDefault();

--- a/manifest.json
+++ b/manifest.json
@@ -31,9 +31,7 @@
         "https://github.com/copilot*",
         "https://github.com/spark*",
         "https://poe.com/*",
-        "https://v0.app/*",
-        "https://cursor.com/agents*",
-        "https://cursor.com/*/agents*"
+        "https://v0.app/*"
       ],
       "js": [
         "content/ctrl-enter-utils.js",
@@ -61,10 +59,11 @@
     "https://github.com/spark*",
     "https://grok.com/*",
     "https://copilot.microsoft.com/*",
-    "https://m365.cloud.microsoft/*",
-    "https://cursor.com/*"
+    "https://m365.cloud.microsoft/*"
   ],
   "optional_host_permissions": [
+    "https://cursor.com/agents*",
+    "https://cursor.com/*/agents*",
     "https://www.genspark.ai/*",
     "https://duck.ai/*",
     "https://manus.im/*"

--- a/options/options.css
+++ b/options/options.css
@@ -28,6 +28,23 @@ label {
   border-radius: 4px;
 }
 
+.grant-button {
+  font-size: 12px;
+  font-family: inherit;
+  margin-left: 8px;
+  padding: 2px 10px;
+  background-color: #4CAF50;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  transition: opacity 0.2s ease;
+}
+
+.grant-button:hover {
+  opacity: 0.85;
+}
+
 #saveButton {
   min-width: 100px;
   padding: 10px 20px;
@@ -74,6 +91,11 @@ label {
   }
 
   #saveButton {
+    background-color: #4BD865;
+    color: #202123;
+  }
+
+  .grant-button {
     background-color: #4BD865;
     color: #202123;
   }

--- a/options/options.js
+++ b/options/options.js
@@ -1,22 +1,54 @@
-import { SUPPORTED_SITES } from "../constants/site-configs.js";
+import { SITE_CONFIGS, SUPPORTED_SITES } from "../constants/site-configs.js";
 
 const siteList = document.getElementById("siteList");
 const selectAllCheckbox = document.getElementById("selectAll");
 const saveButton = document.getElementById("saveButton");
 
-// Render checkbox list based on the SUPPORTED_SITES array
-function renderCheckboxes(savedSettings = {}) {
+// Optional sites need a host permission granted by the user before their
+// content script can run; ungranted ones get an "Allow access" button instead
+// of a usable checkbox.
+async function getUngrantedOptionalSites() {
+  const ungranted = new Set();
+  for (const config of SITE_CONFIGS) {
+    if (!config.optional) continue;
+    const granted = await chrome.permissions.contains({ origins: config.matchPatterns });
+    if (!granted) ungranted.add(config.hostname);
+  }
+  return ungranted;
+}
+
+// Render checkbox list based on the SITE_CONFIGS array
+function renderCheckboxes(savedSettings, ungrantedSites) {
   siteList.innerHTML = '';
-  SUPPORTED_SITES.forEach((hostname) => {
+  SITE_CONFIGS.forEach((config) => {
+    const hostname = config.hostname;
+    const needsGrant = ungrantedSites.has(hostname);
+
     const checkbox = document.createElement("input");
     checkbox.type = "checkbox";
     checkbox.id = hostname;
-    checkbox.checked = savedSettings[hostname] ?? true;
+    checkbox.checked = !needsGrant && (savedSettings[hostname] ?? true);
+    checkbox.disabled = needsGrant;
 
     const label = document.createElement("label");
     label.className = "site-label";
     label.appendChild(checkbox);
     label.append(` https://${hostname}`);
+
+    if (needsGrant) {
+      const grantButton = document.createElement("button");
+      grantButton.type = "button";
+      grantButton.className = "grant-button";
+      grantButton.textContent = "Allow access";
+      grantButton.addEventListener("click", () => {
+        chrome.permissions.request({ origins: config.matchPatterns }, (granted) => {
+          if (!granted) return;
+          // Let the background register the content script, then re-render
+          chrome.runtime.sendMessage({ type: "sync-optional-sites" }, loadSettings);
+        });
+      });
+      label.appendChild(grantButton);
+    }
 
     siteList.appendChild(label);
   });
@@ -27,6 +59,7 @@ function saveSettings() {
   const settings = {};
   SUPPORTED_SITES.forEach((hostname) => {
     const checkbox = document.getElementById(hostname);
+    if (checkbox.disabled) return; // permission not granted; nothing to save
     settings[hostname] = checkbox.checked;
   });
 
@@ -46,7 +79,7 @@ selectAllCheckbox.addEventListener("change", () => {
   const allChecked = selectAllCheckbox.checked;
   SUPPORTED_SITES.forEach((hostname) => {
     const checkbox = document.getElementById(hostname);
-    if (checkbox) checkbox.checked = allChecked;
+    if (checkbox && !checkbox.disabled) checkbox.checked = allChecked;
   });
 });
 
@@ -54,6 +87,11 @@ selectAllCheckbox.addEventListener("change", () => {
 saveButton.addEventListener("click", saveSettings);
 
 // Load saved settings on page load
-chrome.storage.sync.get("siteSettings", (data) => {
-  renderCheckboxes(data.siteSettings || {});
-});
+async function loadSettings() {
+  const ungrantedSites = await getUngrantedOptionalSites();
+  chrome.storage.sync.get("siteSettings", (data) => {
+    renderCheckboxes(data.siteSettings || {}, ungrantedSites);
+  });
+}
+
+loadSettings();

--- a/popup/popup.css
+++ b/popup/popup.css
@@ -6,6 +6,36 @@ body {
   color: #DADADA;
 }
 
+[hidden] {
+  display: none !important;
+}
+
+.grant-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+}
+
+.grant-btn {
+  font-size: 13px;
+  font-family: inherit;
+  color: #202123;
+  background-color: #4BD865;
+  border: none;
+  cursor: pointer;
+  text-align: center;
+  padding: 6px 12px;
+  border-radius: 6px;
+  width: 100%;
+  box-sizing: border-box;
+  transition: opacity 0.2s ease;
+}
+
+.grant-btn:hover {
+  opacity: 0.85;
+}
+
 .main-container {
   display: flex;
   flex-direction: column;

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -9,7 +9,7 @@
 
 <body>
   <div class="main-container">
-    <div class="toggle-row">
+    <div class="toggle-row" id="toggleSection" hidden>
       <div class="toggle_button">
         <input id="isEnabled" class="toggle_input" type="checkbox" aria-label="Enable on this site" />
         <label for="isEnabled" class="toggle_label"></label>
@@ -17,6 +17,17 @@
       <div class="message">
         Enable on this site
       </div>
+    </div>
+
+    <div class="grant-section" id="grantSection" hidden>
+      <div class="message">
+        Allow access to this site to use Ctrl+Enter here.
+      </div>
+      <button id="grantButton" class="grant-btn">Enable on this site</button>
+    </div>
+
+    <div class="message" id="unsupportedSection" hidden>
+      This site is not supported.
     </div>
 
     <a href="../options/options.html" id="settingsLink" target="_blank" class="settings-link">

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,41 +1,76 @@
-import { SUPPORTED_SITES, extractHostname } from "../constants/site-configs.js";
+import { SITE_CONFIGS, extractHostname } from "../constants/site-configs.js";
 
-let isEnabled = false;
+const toggleSection = document.querySelector("#toggleSection");
+const grantSection = document.querySelector("#grantSection");
+const unsupportedSection = document.querySelector("#unsupportedSection");
 const toggleButton = document.querySelector("#isEnabled");
+const grantButton = document.querySelector("#grantButton");
 
+let currentTab = null;
+let currentConfig = null;
+
+// activeTab makes tab.url readable here even on sites without a granted
+// host permission (opening the popup counts as invoking the extension)
 chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-  const tab = tabs[0];
-  const hostname = extractHostname(tab.url);
+  currentTab = tabs[0];
+  const hostname = extractHostname(currentTab.url);
+  currentConfig = SITE_CONFIGS.find((c) => c.hostname === hostname) ?? null;
+
+  if (!currentConfig) {
+    unsupportedSection.hidden = false;
+    return;
+  }
+
+  if (currentConfig.optional) {
+    chrome.permissions.contains({ origins: currentConfig.matchPatterns }, (granted) => {
+      if (granted) {
+        showToggle();
+      } else {
+        grantSection.hidden = false;
+      }
+    });
+  } else {
+    showToggle();
+  }
+});
+
+function showToggle() {
+  grantSection.hidden = true;
+  toggleSection.hidden = false;
 
   chrome.storage.sync.get("siteSettings", (data) => {
     const siteSettings = data.siteSettings || {};
-    isEnabled = siteSettings[hostname] ?? true;
+    const isEnabled = siteSettings[currentConfig.hostname] ?? true;
     toggleButton.checked = isEnabled;
-    updateIcon(isEnabled, tab.id, hostname);
+    updateIcon(isEnabled, currentTab.id);
   });
-});
+}
 
 toggleButton.addEventListener("change", () => {
-  chrome.tabs.query({ active: true, currentWindow: true }, (tabs) => {
-    const tab = tabs[0];
-    const hostname = extractHostname(tab.url);
-    isEnabled = toggleButton.checked;
+  const isEnabled = toggleButton.checked;
 
-    chrome.storage.sync.get("siteSettings", (data) => {
-      const siteSettings = data.siteSettings || {};
-      siteSettings[hostname] = isEnabled;
-      chrome.storage.sync.set({ siteSettings }, () => {
-        updateIcon(isEnabled, tab.id, hostname);
-      });
+  chrome.storage.sync.get("siteSettings", (data) => {
+    const siteSettings = data.siteSettings || {};
+    siteSettings[currentConfig.hostname] = isEnabled;
+    chrome.storage.sync.set({ siteSettings }, () => {
+      updateIcon(isEnabled, currentTab.id);
     });
   });
 });
 
-function updateIcon(enabled, tabId, hostname) {
-  if (SUPPORTED_SITES.includes(hostname)) {
-    chrome.action.setIcon({ tabId, path: enabled ? "../icon/enabled.png" : "../icon/disabled.png" });
-    chrome.action.enable(tabId);
-  } else {
-    chrome.action.disable(tabId);
-  }
+grantButton.addEventListener("click", () => {
+  chrome.permissions.request({ origins: currentConfig.matchPatterns }, (granted) => {
+    if (!granted) return;
+    // Wait for the background to register the content script, then reload
+    // the page so it takes effect immediately
+    chrome.runtime.sendMessage({ type: "sync-optional-sites" }, () => {
+      chrome.tabs.reload(currentTab.id);
+      showToggle();
+    });
+  });
+});
+
+function updateIcon(enabled, tabId) {
+  chrome.action.setIcon({ tabId, path: enabled ? "../icon/enabled.png" : "../icon/disabled.png" });
+  chrome.action.enable(tabId);
 }

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -71,6 +71,6 @@ grantButton.addEventListener("click", () => {
 });
 
 function updateIcon(enabled, tabId) {
-  chrome.action.setIcon({ tabId, path: enabled ? "../icon/enabled.png" : "../icon/disabled.png" });
+  chrome.action.setIcon({ tabId, path: enabled ? "icon/enabled.png" : "icon/disabled.png" });
   chrome.action.enable(tabId);
 }

--- a/tests/baseline-manifest-v2.2.2.json
+++ b/tests/baseline-manifest-v2.2.2.json
@@ -6,10 +6,7 @@
   "default_locale": "en",
   "author": "Kamada Masachika",
   "permissions": [
-    "storage",
-    "scripting",
-    "activeTab",
-    "declarativeContent"
+    "storage"
   ],
   "background": {
     "service_worker": "background.js",
@@ -63,11 +60,6 @@
     "https://copilot.microsoft.com/*",
     "https://m365.cloud.microsoft/*",
     "https://cursor.com/*"
-  ],
-  "optional_host_permissions": [
-    "https://www.genspark.ai/*",
-    "https://duck.ai/*",
-    "https://manus.im/*"
   ],
   "action": {
     "default_popup": "popup/popup.html",

--- a/tests/optional-sites.spec.js
+++ b/tests/optional-sites.spec.js
@@ -1,0 +1,60 @@
+/**
+ * Optional-sites infrastructure test.
+ *
+ * Verifies the background service worker boots the opt-in machinery:
+ *   - declarativeContent rules cover every supported site's match pattern
+ *     (this is what keeps the action icon clickable on ungranted sites)
+ *   - no dynamic content scripts are registered while no optional host
+ *     permission has been granted
+ *
+ * NOTE: a reused test-user-data profile can keep running a stale cached
+ * service worker for the unpacked extension, which makes this spec fail
+ * even though the code is correct. If that happens, delete test-user-data
+ * (this loses saved login sessions) or reload the extension once via
+ * chrome://extensions in that profile.
+ */
+const { test } = require("./fixtures");
+const { expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
+
+async function getServiceWorker(context) {
+  if (context.serviceWorkers().length > 0) {
+    return context.serviceWorkers()[0];
+  }
+  return context.waitForEvent("serviceworker");
+}
+
+test.describe("Optional Sites", () => {
+  test("declarativeContent rules cover all supported match patterns", async ({ context }) => {
+    const serviceWorker = await getServiceWorker(context);
+
+    // Rules are registered asynchronously from onInstalled/onStartup
+    await expect(async () => {
+      const rules = await serviceWorker.evaluate(
+        () => new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve))
+      );
+      expect(rules.length).toBe(1);
+
+      // one condition per match pattern: static content_scripts + optional hosts
+      const manifest = JSON.parse(fs.readFileSync(path.join(__dirname, "..", "manifest.json"), "utf-8"));
+      const patternCount =
+        manifest.content_scripts[0].matches.length + manifest.optional_host_permissions.length;
+      expect(rules[0].conditions.length).toBe(patternCount);
+    }).toPass({ timeout: 5000 });
+  });
+
+  test("no dynamic content scripts while no optional permission is granted", async ({ context }) => {
+    const serviceWorker = await getServiceWorker(context);
+
+    const granted = await serviceWorker.evaluate(() =>
+      chrome.permissions.contains({ origins: ["https://www.genspark.ai/*"] })
+    );
+    test.skip(granted, "profile already has the optional permission granted");
+
+    const registered = await serviceWorker.evaluate(() =>
+      chrome.scripting.getRegisteredContentScripts()
+    );
+    expect(registered).toEqual([]);
+  });
+});

--- a/tests/permission-warnings.spec.js
+++ b/tests/permission-warnings.spec.js
@@ -1,0 +1,53 @@
+/**
+ * Permission-warning regression test.
+ *
+ * Chrome disables an extension on update (until the user re-approves) only
+ * when the new version introduces permission WARNINGS that the old version
+ * did not have. This test compares the current manifest against the last
+ * released baseline and fails if any new warning would appear — i.e. it
+ * guarantees the next update installs silently for all existing users.
+ *
+ * chrome.management.getPermissionWarningsByManifest() is callable without
+ * the "management" permission.
+ */
+const { test } = require("./fixtures");
+const { expect } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
+
+const BASELINE_MANIFEST = path.join(__dirname, "baseline-manifest-v2.2.2.json");
+const CURRENT_MANIFEST = path.join(__dirname, "..", "manifest.json");
+
+function getPermissionWarnings(serviceWorker, manifestJson) {
+  return serviceWorker.evaluate(
+    (manifestStr) =>
+      new Promise((resolve) => {
+        chrome.management.getPermissionWarningsByManifest(manifestStr, resolve);
+      }),
+    manifestJson
+  );
+}
+
+test.describe("Permission Warnings", () => {
+  test("update must not introduce new permission warnings", async ({ context }) => {
+    let serviceWorker;
+    if (context.serviceWorkers().length > 0) {
+      serviceWorker = context.serviceWorkers()[0];
+    } else {
+      serviceWorker = await context.waitForEvent("serviceworker");
+    }
+
+    const baseline = fs.readFileSync(BASELINE_MANIFEST, "utf-8");
+    const current = fs.readFileSync(CURRENT_MANIFEST, "utf-8");
+
+    const baselineWarnings = await getPermissionWarnings(serviceWorker, baseline);
+    const currentWarnings = await getPermissionWarnings(serviceWorker, current);
+
+    console.log("  Baseline (v2.2.2) warnings:", baselineWarnings);
+    console.log("  Current manifest warnings:", currentWarnings);
+
+    for (const warning of currentWarnings) {
+      expect(baselineWarnings, `New permission warning would disable the extension for all users on update: "${warning}"`).toContain(warning);
+    }
+  });
+});

--- a/tools/check_supported_sites.py
+++ b/tools/check_supported_sites.py
@@ -50,8 +50,10 @@ def main():
     for cs in manifest["content_scripts"]:
         matches.extend(cs["matches"])
     host_permissions = manifest["host_permissions"]
+    optional_host_permissions = manifest.get("optional_host_permissions", [])
     domains_matches = [extract_domain(u) for u in matches]
     domains_host_permissions = [extract_domain(u) for u in host_permissions]
+    domains_optional = [extract_domain(u) for u in optional_host_permissions]
 
     # 2. Load all README files and extract domains from the Features/機能/功能 section
     readme_files = [
@@ -69,46 +71,65 @@ def main():
         urls = extract_urls_from_section(section)
         domains_from_readmes.update(urls)
 
-    # 3. Load site-configs.js and extract hostnames
+    # 3. Load site-configs.js and extract hostnames, split by optional flag.
+    # Required sites must appear in manifest matches/host_permissions;
+    # optional sites must appear in optional_host_permissions instead.
     with open(f"{REPO_ROOT}/constants/site-configs.js", encoding="utf-8") as f:
         js = f.read()
-    supported_sites = re.findall(r'hostname:\s*"([^"]+)"', js)
-    domains_supported_sites = [extract_domain(u) for u in supported_sites]
-
-    # Also extract matchPatterns from site-configs.js and verify against manifest
-    config_match_patterns = re.findall(r'"(https://[^"]+)"', js)
-    domains_config_matches = [extract_domain(u) for u in config_match_patterns]
+    domains_supported_sites = []
+    domains_required_sites = []
+    domains_optional_sites = []
+    domains_required_matches = []
+    for entry in re.finditer(r'\{(?P<body>[^{}]*hostname:[^{}]*)\}', js):
+        body = entry.group("body")
+        hostname = re.search(r'hostname:\s*"([^"]+)"', body).group(1)
+        patterns = re.findall(r'"(https://[^"]+)"', body)
+        domain = extract_domain(hostname)
+        domains_supported_sites.append(domain)
+        if re.search(r'optional:\s*true', body):
+            domains_optional_sites.append(domain)
+        else:
+            domains_required_sites.append(domain)
+            domains_required_matches.extend(extract_domain(u) for u in patterns)
 
     # 4. Compare sets
     def diff(a, b):
         return sorted(set(a) - set(b))
 
+    all_manifest_domains = domains_host_permissions + domains_optional
+
     print("--- manifest.json matches vs host_permissions ---")
     print("In matches but not in host_permissions:", diff(domains_matches, domains_host_permissions))
     print("In host_permissions but not in matches:", diff(domains_host_permissions, domains_matches))
 
-    print("\n--- host_permissions vs all README files ---")
-    print("In host_permissions but not in any README:", diff(domains_host_permissions, domains_from_readmes))
-    print("In any README but not in host_permissions:", diff(domains_from_readmes, domains_host_permissions))
+    print("\n--- manifest (host_permissions + optional) vs all README files ---")
+    print("In manifest but not in any README:", diff(all_manifest_domains, domains_from_readmes))
+    print("In any README but not in manifest:", diff(domains_from_readmes, all_manifest_domains))
 
-    print("\n--- host_permissions vs site-configs.js hostnames ---")
-    print("In host_permissions but not in site-configs.js:", diff(domains_host_permissions, domains_supported_sites))
-    print("In site-configs.js but not in host_permissions:", diff(domains_supported_sites, domains_host_permissions))
+    print("\n--- host_permissions vs required sites in site-configs.js ---")
+    print("In host_permissions but not required in site-configs.js:", diff(domains_host_permissions, domains_required_sites))
+    print("Required in site-configs.js but not in host_permissions:", diff(domains_required_sites, domains_host_permissions))
 
-    print("\n--- manifest matches vs site-configs.js matchPatterns ---")
-    print("In manifest matches but not in site-configs.js:", diff(domains_matches, domains_config_matches))
-    print("In site-configs.js but not in manifest matches:", diff(domains_config_matches, domains_matches))
+    print("\n--- optional_host_permissions vs optional sites in site-configs.js ---")
+    print("In optional_host_permissions but not optional in site-configs.js:", diff(domains_optional, domains_optional_sites))
+    print("Optional in site-configs.js but not in optional_host_permissions:", diff(domains_optional_sites, domains_optional))
+
+    print("\n--- manifest matches vs required matchPatterns in site-configs.js ---")
+    print("In manifest matches but not in site-configs.js:", diff(domains_matches, domains_required_matches))
+    print("In site-configs.js but not in manifest matches:", diff(domains_required_matches, domains_matches))
 
     # Exit with error if there are any differences
     if any([
         diff(domains_matches, domains_host_permissions),
         diff(domains_host_permissions, domains_matches),
-        diff(domains_host_permissions, domains_from_readmes),
-        diff(domains_from_readmes, domains_host_permissions),
-        diff(domains_host_permissions, domains_supported_sites),
-        diff(domains_supported_sites, domains_host_permissions),
-        diff(domains_matches, domains_config_matches),
-        diff(domains_config_matches, domains_matches),
+        diff(all_manifest_domains, domains_from_readmes),
+        diff(domains_from_readmes, all_manifest_domains),
+        diff(domains_host_permissions, domains_required_sites),
+        diff(domains_required_sites, domains_host_permissions),
+        diff(domains_optional, domains_optional_sites),
+        diff(domains_optional_sites, domains_optional),
+        diff(domains_matches, domains_required_matches),
+        diff(domains_required_matches, domains_matches),
     ]):
         sys.exit(1)
 


### PR DESCRIPTION
## Summary

New sites (Genspark, duck.ai, Manus) and cursor.com are now opt-in via \optional_host_permissions\, so updates never disable the extension for existing users.

## Changes

### Optional host permissions infrastructure
- New sites use \optional_host_permissions\ instead of required \host_permissions\
- Dynamic content script registration in \ackground.js\ for opted-in sites
- Popup shows "Enable on this site" button for optional sites
- Options page shows "Allow access" for optional sites
- \declarativeContent\ for icon visibility on optional sites

### Site handler fixes
- **Genspark**: Added \onCtrlEnter\ (clicks \.enter-icon-wrapper\) and proper \onEnter\ with newline insertion
- **duck.ai**: Added \onCtrlEnter\ (clicks submit button) and proper \onEnter\ with newline insertion
- **Manus**: Already working correctly

### cursor.com moved to optional
- Moved from \host_permissions\ to \optional_host_permissions\ (reduces required permission scope, addresses #122)
- READMEs updated (EN/JA/ZH) to mark cursor.com as opt-in

### Permission warning guard
- \	ests/permission-warnings.spec.js\: Compares current manifest warnings against v2.2.2 baseline using Chrome API. Fails if any new warning would appear.

## Verification
- [x] Existing sites (ChatGPT etc.) work as before
- [x] Genspark: Enter=newline, Ctrl+Enter=send
- [x] duck.ai: Enter=newline, Ctrl+Enter=send
- [x] Manus: Enter=newline, Ctrl+Enter=send
- [x] Opt-in flow (popup Enable button) works
- [x] No new permission warnings vs v2.2.2