### PR TITLE
Merge pull request guidance into main

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,7 +1,13 @@
 <!-- Thank you for submitting a Pull Request. Please:
 * Associate an issue with the Pull Request.
-* Ensure that the code is up-to-date with the `main` branch.
+* Use `development` as the base branch for regular changes.
+* Use `main` as the base branch only for release pull requests from `development`.
+* Ensure that the code is up-to-date with the `development` branch.
 * Include a description of the proposed changes and how to test them.
 -->
+
+> [!IMPORTANT]
+> Set the base branch to `development` for regular pull requests.
+> Only release pull requests from `development` may target `main`.
 
 > To enable us to quickly review and accept your pull requests, always create one pull request per issue and link the issue in the pull request. ***Never merge multiple requests in one unless they have the same root cause.*** Be sure to follow our Coding Guidelines and keep code changes as ***small*** as possible. Avoid pure formatting changes to code that has not been modified otherwise. Pull requests should contain tests whenever possible. (https://github.com/microsoft/vscode/wiki/How-to-Contribute#pull-requests)


### PR DESCRIPTION
## Summary

- Publish the updated pull request template on the default branch
- Direct regular pull requests to `development`
- Reserve pull requests targeting `main` for releases from `development`

## Testing

- Not run because this change only updates the pull request template

## Release impact

- No extension code changes
- No version bump or Chrome Web Store release required