### PR TITLE
chore: add MIT license and align package metadata

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 Masachika Kamada
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "1.0.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-ctrl-enter-sender",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "2.3.1",
+      "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2"
       }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "1.0.0",
-  "description": "English | [日本語](README_JA.md) | [简体中文](README_CH.md)",
+  "version": "2.3.1",
+  "private": true,
+  "description": "Browser extension that assigns Ctrl+Enter to send messages in ChatGPT and other AI chat sites, so Enter inserts a line break",
   "main": "background.js",
   "scripts": {
     "test": "npm run test:unit && npm run test:integration",
@@ -20,8 +21,8 @@
     "url": "git+https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender.git"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "Masachika Kamada",
+  "license": "MIT",
   "type": "commonjs",
   "bugs": {
     "url": "https://github.com/masachika-kamada/ChatGPT-Ctrl-Enter-Sender/issues"


### PR DESCRIPTION
## Summary

- Add the MIT `LICENSE` file.
- Update `package.json` metadata:
  - Align the version with the current extension release (`2.3.1`).
  - Mark the package as private.
  - Replace the placeholder description and author fields.
  - Change the declared license from ISC to MIT.
- Regenerate `package-lock.json` so its root package metadata matches `package.json`.

## Testing

- `npm test`