### PR TITLE
feat(kimi): add Kimi support as an opt-in site

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ These sites are supported but maintained on a best-effort basis:
 
 ### Tier 3 — Minimal Support
 These sites may be removed if they become unmaintainable:
-- Poe, v0, Cursor, Genspark, duck.ai, Manus
+- Poe, v0, Cursor, Genspark, duck.ai, Manus, Kimi
 
 ## How New Sites Are Shipped (Opt-in)
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ You can use this extension on the following pages:
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
+* <https://www.kimi.com> (opt-in)
 
 *Opt-in sites: to keep updates from requiring new permissions for everyone, these sites are enabled per user. Open the site, click the extension icon, and press "Enable on this site" once.*
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -42,6 +42,7 @@
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
+* <https://www.kimi.com> (opt-in)
 
 *可选站点: 为避免更新时要求所有用户重新授权，这些站点需按用户启用。打开站点，点击扩展图标，然后按一次 "Enable on this site"。*
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -42,6 +42,7 @@
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
+* <https://www.kimi.com> (opt-in)
 
 *オプトイン サイト: 全ユーザーへの権限再承認を避けるため、これらのサイトはユーザーごとに有効化する方式です。サイトを開いて拡張機能のアイコンをクリックし、「Enable on this site」を一度押してください。*
 

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -34,6 +34,7 @@ export const SITE_CONFIGS = [
   { hostname: "www.genspark.ai", matchPatterns: ["https://www.genspark.ai/*"], optional: true },
   { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"], optional: true },
   { hostname: "manus.im", matchPatterns: ["https://manus.im/*"], optional: true },
+  { hostname: "www.kimi.com", matchPatterns: ["https://www.kimi.com/*"], optional: true },
 ];
 
 export const OPTIONAL_SITE_CONFIGS = SITE_CONFIGS.filter((c) => c.optional);

--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -373,6 +373,27 @@ const SITE_BEHAVIORS = {
       dispatchEnter(event.target, {});
     },
   },
+
+  "www.kimi.com": {
+    shouldHandle(event) {
+      return event.target.tagName === "DIV" &&
+        event.target.contentEditable === "true" &&
+        event.target.getAttribute("data-lexical-editor") === "true" &&
+        event.target.getAttribute("role") === "textbox";
+    },
+    onEnter(event) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      dispatchEnter(event.target, { shiftKey: true });
+    },
+    onCtrlEnter(event) {
+      // Kimi maps Ctrl+Enter to a line break, so the native handler must be
+      // stopped before dispatching the plain Enter that submits
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      dispatchEnter(event.target, {});
+    },
+  },
 };
 
 // ── Unified handler ──────────────────────────────────────────────────────────

--- a/manifest.json
+++ b/manifest.json
@@ -66,7 +66,8 @@
     "https://cursor.com/*/agents*",
     "https://www.genspark.ai/*",
     "https://duck.ai/*",
-    "https://manus.im/*"
+    "https://manus.im/*",
+    "https://www.kimi.com/*"
   ],
   "action": {
     "default_popup": "popup/popup.html",


### PR DESCRIPTION
Kimi maps Enter to submit, and both Shift+Enter and Ctrl+Enter to a line break, so Ctrl+Enter currently does the opposite of what this extension provides.

The prompt input is a Lexical editor, so the behavior reuses the data-lexical-editor detection from cursor.com with the site-wide scope of manus.im. Line breaks are inserted by dispatching a synthetic Shift+Enter; document.execCommand("insertLineBreak") was tried first, but Lexical resets its state on the unmanaged DOM change and the typed input is lost.

Shipped as opt-in via optional_host_permissions so the update does not disable the extension for existing users.