### PR TITLE
Add safe extension reload and improve ChatGPT submission

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Repository instructions
+
+## 仕様の正本
+
+- 仕様の正本: `README.md`
+- 実装前に意図する仕様を正本へ反映し、仕様変更時は同じ変更で正本と検証を更新する。
+
+## Repository boundaries
+
+- このリポジトリの責務と既存の利用者向け挙動を維持する。
+- README、CONTRIBUTING、docs、既存テストに矛盾がある場合は、実装だけを正として進めず差分を解消する。
+
+## Verification
+
+- リポジトリに記載されたtest、build、lint、typecheck、E2Eの入口を使用する。
+- 仕様、実装、テスト、利用者向け文書が一致するまで完了扱いにしない。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,6 +10,11 @@
 - このリポジトリの責務と既存の利用者向け挙動を維持する。
 - README、CONTRIBUTING、docs、既存テストに矛盾がある場合は、実装だけを正として進めず差分を解消する。
 
+## ブラウザ拡張機能の更新
+
+- 拡張機能の読み込み対象はルート`manifest.json`、`background.js`、`content/`、`popup/`、`options/`を含むこのリポジトリ直下とする。変更時は共有`browser-extension-update-delivery`を適用し、`scripts/reload-extension.ps1`で自己再読み込みと`expectedVersion`／`expectedBuildId`の反映確認まで行う。
+- `chrome://extensions`をユーザーの前面に開いたり、ユーザーへReload操作を依頼したりして完了扱いにしない。安全な機械実行経路がなければ、その経路の追加または修復を同じ作業に含める。
+
 ## Verification
 
 - リポジトリに記載されたtest、build、lint、typecheck、E2Eの入口を使用する。

--- a/README.md
+++ b/README.md
@@ -62,6 +62,16 @@ If you encounter any issues, we recommend disabling these extensions temporarily
 This extension has been confirmed not to work on Microsoft domains such as `copilot.microsoft.com` and `m365.cloud.microsoft` when using Microsoft Edge (as of July 2026).<br>
 If you experience this issue, please try using Chrome or another Chromium-based browser.
 
+## Agent-managed development reload
+
+After an unpacked development copy has been loaded once, repository agents must run the following command after extension-source changes. It updates the local build marker, requests `chrome.runtime.reload()` over a loopback-only control channel, and waits for the restarted extension to report the expected version and build ID. It does not open `chrome://extensions` or operate the user's active tabs.
+
+```powershell
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/reload-extension.ps1
+```
+
+The `alarms`, `storage`, and `http://127.0.0.1:18792/*` permissions are used only for this local development reload handshake.
+
 ## Contributors
 
 <a href="https://github.com/ry0y4n"><img src="https://github.com/ry0y4n.png" width="40"></a>

--- a/agent-build.json
+++ b/agent-build.json
@@ -1,0 +1,3 @@
+{
+  "buildId": "bootstrap"
+}

--- a/agent-reload.js
+++ b/agent-reload.js
@@ -1,0 +1,70 @@
+const EXTENSION = 'chatgpt-sender';
+const PORT = 18792;
+const BASE_URL = `http://127.0.0.1:${PORT}/v1/extension-reload`;
+const ALARM = 'agent-extension-reload';
+let checkInFlight = false;
+
+async function readBuild() {
+  const response = await fetch(`${chrome.runtime.getURL('agent-build.json')}?t=${Date.now()}`, {
+    cache: 'no-store'
+  });
+  if (!response.ok) throw new Error(`agent-build.json: ${response.status}`);
+  return response.json();
+}
+
+async function sendAck(phase, command, buildId) {
+  const manifest = chrome.runtime.getManifest();
+  const response = await fetch(`${BASE_URL}/ack`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    cache: 'no-store',
+    body: JSON.stringify({
+      extension: EXTENSION,
+      requestId: command.requestId,
+      phase,
+      version: manifest.version,
+      buildId,
+      extensionId: chrome.runtime.id
+    })
+  });
+  if (!response.ok) throw new Error(`reload ack failed: ${response.status}`);
+}
+
+async function checkForReload() {
+  if (checkInFlight) return;
+  checkInFlight = true;
+  try {
+    const response = await fetch(`${BASE_URL}?extension=${encodeURIComponent(EXTENSION)}`, {
+      cache: 'no-store'
+    });
+    if (!response.ok) return;
+    const command = await response.json();
+    if (command.command !== 'reload' && command.command !== 'verify_loaded') return;
+
+    const manifest = chrome.runtime.getManifest();
+    const build = await readBuild();
+    if (command.expectedVersion !== manifest.version || command.expectedBuildId !== build.buildId) return;
+
+    if (command.command === 'verify_loaded') {
+      await sendAck('loaded', command, build.buildId);
+      return;
+    }
+
+    await sendAck('reloading', command, build.buildId);
+    chrome.runtime.reload();
+  } catch (_error) {
+    // The loopback development server is normally absent during regular use.
+  } finally {
+    checkInFlight = false;
+  }
+}
+
+chrome.alarms.create(ALARM, { delayInMinutes: 0.5, periodInMinutes: 0.5 });
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === ALARM) void checkForReload();
+});
+chrome.runtime.onStartup.addListener(() => void checkForReload());
+chrome.runtime.onInstalled.addListener(() => void checkForReload());
+void checkForReload();
+setTimeout(() => void checkForReload(), 5000);
+setTimeout(() => void checkForReload(), 10000);

--- a/background.js
+++ b/background.js
@@ -1,3 +1,4 @@
+import './agent-reload.js';
 import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS, SUPPORTED_SITES, extractHostname } from "./constants/site-configs.js";
 
 // ── Action icon visibility ───────────────────────────────────────────────────

--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -65,7 +65,15 @@ const SITE_BEHAVIORS = {
       // Only intercept Ctrl (not Meta); Mac Cmd+Enter works natively on ChatGPT
       if (!event.ctrlKey) return;
       event.preventDefault();
-      dispatchEnter(event.target, { metaKey: true });
+      const submitButton = findFormButton(
+        event.target,
+        'button[data-testid$="send-button"]:not([disabled]), button[type="submit"]:not([disabled])'
+      );
+      if (submitButton) {
+        submitButton.click();
+      } else {
+        dispatchEnter(event.target, { metaKey: true });
+      }
     },
   },
 

--- a/manifest.json
+++ b/manifest.json
@@ -6,6 +6,7 @@
   "default_locale": "en",
   "author": "Kamada Masachika",
   "permissions": [
+    "alarms",
     "storage",
     "scripting",
     "activeTab",
@@ -46,6 +47,7 @@
     "128": "icon/icon128.png"
   },
   "host_permissions": [
+    "http://127.0.0.1:18792/*",
     "https://chatgpt.com/*",
     "https://poe.com/*",
     "https://chat.mistral.ai/*",

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "node --test tools/ctrl-enter-handler.test.js",
+    "test:agent-reload": "node tools/agent-reload.test.js",
     "test:integration": "playwright test",
     "test:loading": "playwright test extension-loading",
     "test:live": "playwright test --config=playwright.live.config.js",

--- a/scripts/reload-extension.ps1
+++ b/scripts/reload-extension.ps1
@@ -1,0 +1,42 @@
+param(
+  [int]$TimeoutSeconds = 90
+)
+
+$ErrorActionPreference = 'Stop'
+$repoRoot = Split-Path -Parent $PSScriptRoot
+$manifestPath = Join-Path $repoRoot 'manifest.json'
+$buildPath = Join-Path $repoRoot 'agent-build.json'
+$helperPath = 'C:\00_dev\.agents\skills\browser-extension-update-delivery\scripts\invoke_reload_server.ps1'
+
+if (-not (Test-Path -LiteralPath $helperPath)) {
+  throw "Shared extension reload helper is missing: $helperPath"
+}
+
+$manifest = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+$originalBuild = if (Test-Path -LiteralPath $buildPath) { [IO.File]::ReadAllText($buildPath) } else { $null }
+$buildId = [Guid]::NewGuid().ToString('N')
+$exitCode = 1
+
+try {
+  $payload = [ordered]@{
+    buildId = $buildId
+    generatedAt = [DateTime]::UtcNow.ToString('o')
+  } | ConvertTo-Json
+  [IO.File]::WriteAllText($buildPath, $payload + [Environment]::NewLine, [Text.UTF8Encoding]::new($false))
+
+  & $helperPath `
+    -Port 18792 `
+    -Extension chatgpt-sender `
+    -ExpectedVersion ([string]$manifest.version) `
+    -ExpectedBuildId $buildId `
+    -TimeoutSeconds ([Math]::Max(5, $TimeoutSeconds))
+  $exitCode = $LASTEXITCODE
+} finally {
+  if ($null -eq $originalBuild) {
+    Remove-Item -LiteralPath $buildPath -Force -ErrorAction SilentlyContinue
+  } else {
+    [IO.File]::WriteAllText($buildPath, $originalBuild, [Text.UTF8Encoding]::new($false))
+  }
+}
+
+exit $exitCode

--- a/tools/agent-reload.test.js
+++ b/tools/agent-reload.test.js
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+const root = path.resolve(__dirname, '..');
+const manifest = JSON.parse(fs.readFileSync(path.join(root, 'manifest.json'), 'utf8'));
+const background = fs.readFileSync(path.join(root, 'background.js'), 'utf8');
+const client = fs.readFileSync(path.join(root, 'agent-reload.js'), 'utf8');
+const script = fs.readFileSync(path.join(root, 'scripts', 'reload-extension.ps1'), 'utf8');
+const combined = `${client}\n${script}`.toLowerCase();
+
+assert.ok(manifest.permissions.includes('alarms'));
+assert.ok(manifest.permissions.includes('storage'));
+assert.ok(manifest.host_permissions.includes('http://127.0.0.1:18792/*'));
+assert.match(background, /import ['"]\.\/agent-reload\.js['"]/);
+assert.match(client, /chrome\.runtime\.reload\(\)/);
+assert.match(combined, /expectedbuildid/);
+assert.doesNotMatch(combined, /chrome:\/\/extensions/);
+assert.doesNotMatch(combined, /setforegroundwindow|sendkeys/);
+
+console.log('agent reload contract: PASS');

--- a/tools/ctrl-enter-handler.test.js
+++ b/tools/ctrl-enter-handler.test.js
@@ -8,6 +8,7 @@ const handlerScriptPath = path.join(__dirname, "..", "content", "ctrl-enter-hand
 const handlerScript = fs.readFileSync(handlerScriptPath, "utf8");
 const submitSelector = 'button[type="submit"]:not([disabled])';
 const notebookSubmitSelector = 'query-box form button[type="submit"]';
+const chatgptSubmitSelector = 'button[data-testid$="send-button"]:not([disabled]), button[type="submit"]:not([disabled])';
 
 function loadHandler(url, sendButton, documentButtonSelector = submitSelector) {
   const parsedUrl = new URL(url);
@@ -15,7 +16,13 @@ function loadHandler(url, sendButton, documentButtonSelector = submitSelector) {
     window: { location: { href: url, hostname: parsedUrl.hostname } },
     URL,
     document: {
-      querySelector: (selector) => (selector === documentButtonSelector ? sendButton : null)
+      querySelector: (selector) => {
+        if (selector === documentButtonSelector || selector === submitSelector || selector === chatgptSubmitSelector) {
+          if (sendButton && sendButton.disabled) return null;
+          return sendButton;
+        }
+        return null;
+      }
     },
     chrome: {
       storage: {
@@ -63,7 +70,13 @@ function createLexicalTarget({ formSendButton = null, attributes = {} } = {}) {
     closest: (selector) => {
       if (selector !== "form" || !formSendButton) return null;
       return {
-        querySelector: (query) => (query === submitSelector ? formSendButton : null)
+        querySelector: (query) => {
+          if (query === submitSelector || query === chatgptSubmitSelector) {
+            if (formSendButton && formSendButton.disabled) return null;
+            return formSendButton;
+          }
+          return null;
+        }
       };
     }
   };
@@ -127,8 +140,9 @@ function createKeydownEvent(target, { ctrlKey = false, metaKey = false, shiftKey
   };
 }
 
-function createButton() {
+function createButton({ disabled = false } = {}) {
   return {
+    disabled,
     clickCount: 0,
     click() {
       this.clickCount += 1;
@@ -428,13 +442,30 @@ test("Copilot の TEXTAREA で Ctrl+Enter はパススルー", () => {
 
 // ── ChatGPT tests ────────────────────────────────────────────────────────────
 
-test("ChatGPT の prompt-textarea で Enter は Shift+Enter にマッピング", () => {
+function createChatGPTTarget({ formSendButton = null, id = "prompt-textarea", tagName = "DIV" } = {}) {
   const dispatchedEvents = [];
   const target = {
-    id: "prompt-textarea",
-    tagName: "DIV",
-    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; }
+    id,
+    tagName,
+    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; },
+    closest: (selector) => {
+      if (selector !== "form" || !formSendButton) return null;
+      return {
+        querySelector: (query) => {
+          if (query === submitSelector || query === chatgptSubmitSelector) {
+            if (formSendButton && formSendButton.disabled) return null;
+            return formSendButton;
+          }
+          return null;
+        }
+      };
+    }
   };
+  return { target, dispatchedEvents };
+}
+
+test("ChatGPT の prompt-textarea で Enter は Shift+Enter にマッピング", () => {
+  const { target, dispatchedEvents } = createChatGPTTarget();
   const context = loadHandler("https://chatgpt.com/", createButton());
   const event = createKeydownEvent(target);
 
@@ -445,14 +476,22 @@ test("ChatGPT の prompt-textarea で Enter は Shift+Enter にマッピング",
   assert.equal(dispatchedEvents[0].shiftKey, true);
 });
 
-test("ChatGPT の prompt-textarea で Ctrl+Enter は Meta+Enter にマッピング", () => {
-  const dispatchedEvents = [];
-  const target = {
-    id: "prompt-textarea",
-    tagName: "DIV",
-    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; }
-  };
-  const context = loadHandler("https://chatgpt.com/", createButton());
+test("ChatGPT で Ctrl+Enter 時、form 内に有効な submit button があれば click される", () => {
+  const formSendButton = createButton();
+  const { target, dispatchedEvents } = createChatGPTTarget({ formSendButton });
+  const context = loadHandler("https://chatgpt.com/", formSendButton);
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(dispatchedEvents.length, 0); // button is clicked, so no synthetic enter is dispatched
+  assert.equal(formSendButton.clickCount, 1);
+});
+
+test("ChatGPT で Ctrl+Enter 時、有効な submit button がなければ従来通り Meta+Enter を dispatch する", () => {
+  const { target, dispatchedEvents } = createChatGPTTarget({ formSendButton: null });
+  const context = loadHandler("https://chatgpt.com/", null);
   const event = createKeydownEvent(target, { ctrlKey: true });
 
   context.handleCtrlEnter(event);
@@ -462,13 +501,22 @@ test("ChatGPT の prompt-textarea で Ctrl+Enter は Meta+Enter にマッピン�
   assert.equal(dispatchedEvents[0].metaKey, true);
 });
 
+test("ChatGPT で Ctrl+Enter 時、disabled button はクリックしない（fallback する）", () => {
+  const formSendButton = createButton({ disabled: true });
+  const { target, dispatchedEvents } = createChatGPTTarget({ formSendButton });
+  const context = loadHandler("https://chatgpt.com/", formSendButton);
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(dispatchedEvents.length, 1); // falls back to Meta+Enter
+  assert.equal(dispatchedEvents[0].metaKey, true);
+  assert.equal(formSendButton.clickCount, 0); // button not clicked
+});
+
 test("ChatGPT の Meta+Enter はパススルー（Mac ネイティブ送信）", () => {
-  const dispatchedEvents = [];
-  const target = {
-    id: "prompt-textarea",
-    tagName: "DIV",
-    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; }
-  };
+  const { target, dispatchedEvents } = createChatGPTTarget();
   const context = loadHandler("https://chatgpt.com/", createButton());
   const event = createKeydownEvent(target, { metaKey: true });
 


### PR DESCRIPTION
Adds repository agent/spec guidance, improves ChatGPT Ctrl+Enter submission with tested button fallback behavior, and adds loopback-only agent-managed chrome.runtime.reload verification. Rebased onto upstream 2.4.0; 25 unit tests and 23 Playwright integration tests passed.