### PR TITLE
[fix] claude edit not working

### DIFF
--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -87,9 +87,16 @@ const SITE_BEHAVIORS = {
       event.preventDefault();
       event.stopImmediatePropagation();
       if (event.target.tagName === "TEXTAREA") {
-        // Edit mode: synthetic Enter would double-submit
-        const saveButton = findFormButton(event.target, 'button[type="submit"]:not([disabled])');
-        if (saveButton) saveButton.click();
+        // Edit mode: no form, and the save button label is localized, so it is
+        // matched by the design system's primary fill
+        const message = event.target.closest('[data-cds="UserMessage"]');
+        const saveButton = message &&
+          message.querySelector('button:not([disabled]):has(> span.bg-fill-primary)');
+        if (saveButton) {
+          saveButton.click();
+        } else {
+          dispatchEnter(event.target, {});
+        }
       } else {
         dispatchEnter(event.target, {});
       }

--- a/tools/ctrl-enter-handler.test.js
+++ b/tools/ctrl-enter-handler.test.js
@@ -8,6 +8,7 @@ const handlerScriptPath = path.join(__dirname, "..", "content", "ctrl-enter-hand
 const handlerScript = fs.readFileSync(handlerScriptPath, "utf8");
 const submitSelector = 'button[type="submit"]:not([disabled])';
 const notebookSubmitSelector = 'query-box form button[type="submit"]';
+const claudeSaveSelector = 'button:not([disabled]):has(> span.bg-fill-primary)';
 
 function loadHandler(url, sendButton, documentButtonSelector = submitSelector) {
   const parsedUrl = new URL(url);
@@ -88,6 +89,26 @@ function createTextareaTarget({ value = "text", formSendButton = null } = {}) {
         querySelector: (query) => (query === submitSelector ? formSendButton : null)
       };
     }
+  };
+
+  return { target, dispatchedEvents };
+}
+
+function createClaudeEditTarget({ saveButton = null, value = "text" } = {}) {
+  const dispatchedEvents = [];
+  const message = {
+    querySelector: (query) => (query === claudeSaveSelector ? saveButton : null)
+  };
+  const target = {
+    tagName: "TEXTAREA",
+    value,
+    selectionStart: value.length,
+    selectionEnd: value.length,
+    dispatchEvent: (event) => {
+      dispatchedEvents.push(event);
+      return true;
+    },
+    closest: (selector) => (selector === '[data-cds="UserMessage"]' ? message : null)
   };
 
   return { target, dispatchedEvents };
@@ -204,6 +225,67 @@ test("Cursor Agents の Meta+Enter は form 内送信ボタンをクリックす
   assert.equal(event.stopImmediatePropagationCount, 1);
   assert.equal(dispatchedEvents.length, 0);
   assert.equal(formSendButton.clickCount, 1);
+});
+
+// ── Claude tests ────────────────────────────────────────────────────────────
+
+test("Claude の編集 TEXTAREA で Enter はカーソル位置に改行を挿入する", () => {
+  const saveButton = createButton();
+  const context = loadHandler("https://claude.ai/chat/abc", createButton());
+  const { target, dispatchedEvents } = createClaudeEditTarget({ saveButton, value: "ab" });
+  target.selectionStart = target.selectionEnd = 1;
+  const event = createKeydownEvent(target);
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(target.value, "a\nb");
+  assert.equal(target.selectionStart, 2);
+  assert.equal(saveButton.clickCount, 0);
+  assert.equal(dispatchedEvents.at(-1).type, "input");
+  assert.equal(event.preventDefaultCount, 1);
+});
+
+test("Claude の編集 TEXTAREA で Ctrl+Enter は保存ボタンを一度クリックする", () => {
+  const saveButton = createButton();
+  const context = loadHandler("https://claude.ai/chat/abc", createButton());
+  const { target, dispatchedEvents } = createClaudeEditTarget({ saveButton });
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(saveButton.clickCount, 1);
+  assert.equal(dispatchedEvents.length, 0);
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(event.stopImmediatePropagationCount, 1);
+});
+
+test("Claude の保存ボタンが見つからない場合は通常 Enter にフォールバックする", () => {
+  const context = loadHandler("https://claude.ai/chat/abc", createButton());
+  const { target, dispatchedEvents } = createClaudeEditTarget();
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(dispatchedEvents.length, 1);
+  assert.equal(dispatchedEvents[0].type, "keydown");
+  assert.equal(dispatchedEvents[0].shiftKey, undefined);
+});
+
+test("Claude の入力欄（contenteditable）の Ctrl+Enter は通常 Enter を送る", () => {
+  const dispatchedEvents = [];
+  const target = {
+    tagName: "DIV",
+    contentEditable: "true",
+    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; }
+  };
+  const context = loadHandler("https://claude.ai/chat/abc", createButton());
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(dispatchedEvents.length, 1);
+  assert.equal(dispatchedEvents[0].shiftKey, undefined);
+  assert.equal(event.preventDefaultCount, 1);
 });
 
 // ── Other optional-site tests ───────────────────────────────────────────────


### PR DESCRIPTION
Closes #149

## 概要

Claudeの編集モードでCtrl+Enterを押しても保存されない問題を修正しました。Claude側のUI変更により，保存ボタンが`<form>`内の`button[type="submit"]`ではなくなったため，`onCtrlEnter`内の従来のセレクタでボタンを取得できず，何も起こらなくなっていました。

## 変更点

`content/ctrl-enter-handler.js`にある`onCtrlEnter`関数を修正しました。

- 保存ボタンの取得を，フォーム内の`type="submit"`検索から，編集中のメッセージ（`[data-cds="UserMessage"]`）配下でデザインシステムのプライマリボタン（`button:not([disabled]):has(> span.bg-fill-primary)`）を探す方式に変更しました。
- 保存ボタンが見つからない場合は，通常のEnterイベントをディスパッチするフォールバック処理を追加しました。

## テスト

`tools/ctrl-enter-handler.test.js`にClaudeの編集モードに関するテストケースを追加しました。

- 編集中のTEXTAREAでのEnterがカーソル位置に改行を挿入すること
- 編集中のTEXTAREAでのCtrl+Enterが保存ボタンを一度だけクリックすること
- 保存ボタンが見つからない場合に通常のEnterへフォールバックすること
- 入力欄（contenteditable）でのCtrl+Enterが通常のEnterを送信すること
