### PR TITLE
Fix opt-in sites not registering after an extension update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,7 +66,8 @@ jobs:
             icon/ \
             options/ \
             popup/ \
-            background.js \
+            shared/ \
+            service-worker.js \
             manifest.json
 
       - name: Create GitHub Release

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -12,10 +12,17 @@
  *
  * When adding a new site:
  *   1. Add an entry here with `optional: true` (hostname + matchPatterns)
- *   2. Add behavior in content/ctrl-enter-handler.js
- *   3. Add the match patterns to optional_host_permissions in manifest.json
- *   4. Run `python tools/check_supported_sites.py` to verify consistency
+ *   2. Bump SITE_CONFIGS_REVISION so a leftover service worker cannot revert it
+ *   3. Add behavior in content/ctrl-enter-handler.js
+ *   4. Add the match patterns to optional_host_permissions in manifest.json
+ *   5. Run `python tools/check_supported_sites.py` to verify consistency
  */
+
+// Generation marker for the site list. shared/site-sync.js records the highest
+// revision that wrote the action rules, so a service worker left running
+// pre-update code cannot overwrite a newer sync with its outdated list.
+export const SITE_CONFIGS_REVISION = 1;
+
 export const SITE_CONFIGS = [
   { hostname: "chatgpt.com", matchPatterns: ["https://chatgpt.com/*"] },
   { hostname: "claude.ai", matchPatterns: ["https://claude.ai/*"] },

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -7,8 +7,8 @@
  *     for every user until they re-enable it. Do NOT add new required sites.
  *   - Optional sites (`optional: true`): covered by optional_host_permissions.
  *     The user grants access per-site from the popup; content scripts are
- *     registered dynamically by background.js. Adding one never disables the
- *     extension for existing users.
+ *     registered dynamically by shared/site-sync.js. Adding one never disables
+ *     the extension for existing users.
  *
  * When adding a new site:
  *   1. Add an entry here with `optional: true` (hostname + matchPatterns)

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",
@@ -12,7 +12,7 @@
     "declarativeContent"
   ],
   "background": {
-    "service_worker": "background.js",
+    "service_worker": "service-worker.js",
     "type": "module"
   },
   "content_scripts": [

--- a/options/options.js
+++ b/options/options.js
@@ -52,7 +52,7 @@ function renderCheckboxes(savedSettings, ungrantedSites) {
         chrome.permissions.request({ origins: config.matchPatterns }, (granted) => {
           if (!granted) return;
           // Register here rather than in the service worker, then re-render
-          syncOptionalContentScripts().then(loadSettings);
+          syncOptionalContentScripts().then(loadSettings, loadSettings);
         });
       });
       label.appendChild(grantButton);

--- a/options/options.js
+++ b/options/options.js
@@ -1,4 +1,9 @@
 import { SITE_CONFIGS, SUPPORTED_SITES } from "../constants/site-configs.js";
+import { syncSiteRegistrations, syncOptionalContentScripts } from "../shared/site-sync.js";
+
+// Repairs action rules and content-script registrations when the service
+// worker is still running pre-update code (see shared/site-sync.js)
+syncSiteRegistrations();
 
 const siteList = document.getElementById("siteList");
 const selectAllCheckbox = document.getElementById("selectAll");
@@ -46,8 +51,8 @@ function renderCheckboxes(savedSettings, ungrantedSites) {
       grantButton.addEventListener("click", () => {
         chrome.permissions.request({ origins: config.matchPatterns }, (granted) => {
           if (!granted) return;
-          // Let the background register the content script, then re-render
-          chrome.runtime.sendMessage({ type: "sync-optional-sites" }, loadSettings);
+          // Register here rather than in the service worker, then re-render
+          syncOptionalContentScripts().then(loadSettings);
         });
       });
       label.appendChild(grantButton);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-ctrl-enter-sender",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "service-worker.js",
   "scripts": {
     "test": "npm run test:unit && npm run test:integration",
-    "test:unit": "node --test tools/ctrl-enter-handler.test.js",
+    "test:unit": "node --test tools/*.test.js",
     "test:integration": "playwright test",
     "test:loading": "playwright test extension-loading",
     "test:live": "playwright test --config=playwright.live.config.js",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "private": true,
   "description": "Browser extension that assigns Ctrl+Enter to send messages in ChatGPT and other AI chat sites, so Enter inserts a line break",
-  "main": "background.js",
+  "main": "service-worker.js",
   "scripts": {
     "test": "npm run test:unit && npm run test:integration",
     "test:unit": "node --test tools/ctrl-enter-handler.test.js",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,8 @@ module.exports = defineConfig({
   testIgnore: "**/live/**",
   timeout: 60000,
   workers: 1,
-  retries: 0,
+  // Extension service worker startup is timing sensitive on loaded CI machines
+  retries: process.env.CI ? 2 : 0,
   reporter: [["html", { open: "never" }], ["list"]],
   use: {
     // Chrome extension tests require a persistent context,

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -77,10 +77,13 @@ grantButton.addEventListener("click", () => {
     if (!granted) return;
     // Register here rather than in the service worker, then reload the page so
     // it takes effect immediately
-    syncOptionalContentScripts().then(() => {
-      chrome.tabs.reload(currentTab.id);
-      showToggle();
-    });
+    syncOptionalContentScripts().then(
+      () => {
+        chrome.tabs.reload(currentTab.id);
+        showToggle();
+      },
+      () => showStatus("Could not enable this site. Please try again.")
+    );
   });
 });
 

--- a/popup/popup.js
+++ b/popup/popup.js
@@ -1,4 +1,9 @@
 import { SITE_CONFIGS, extractHostname } from "../constants/site-configs.js";
+import { syncSiteRegistrations, syncOptionalContentScripts } from "../shared/site-sync.js";
+
+// Repairs action rules and content-script registrations when the service
+// worker is still running pre-update code (see shared/site-sync.js)
+syncSiteRegistrations();
 
 const toggleSection = document.querySelector("#toggleSection");
 const grantSection = document.querySelector("#grantSection");
@@ -70,9 +75,9 @@ toggleButton.addEventListener("change", () => {
 grantButton.addEventListener("click", () => {
   chrome.permissions.request({ origins: currentConfig.matchPatterns }, (granted) => {
     if (!granted) return;
-    // Wait for the background to register the content script, then reload
-    // the page so it takes effect immediately
-    chrome.runtime.sendMessage({ type: "sync-optional-sites" }, () => {
+    // Register here rather than in the service worker, then reload the page so
+    // it takes effect immediately
+    syncOptionalContentScripts().then(() => {
       chrome.tabs.reload(currentTab.id);
       showToggle();
     });

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,72 +1,5 @@
-import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS, SUPPORTED_SITES, extractHostname } from "./constants/site-configs.js";
-
-// ── Action icon visibility ───────────────────────────────────────────────────
-// The action is disabled by default and shown declaratively on supported sites.
-// declarativeContent needs no host access, so the icon stays clickable on
-// optional sites even before the user grants the host permission (the popup is
-// where they grant it).
-
-function matchPatternToRegex(pattern) {
-  return "^" + pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$";
-}
-
-const ACTION_RULE_REGEXES = SITE_CONFIGS.flatMap((config) => config.matchPatterns.map(matchPatternToRegex));
-
-function getActionRules() {
-  return new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
-}
-
-async function ensureActionRules() {
-  chrome.action.disable();
-
-  const rules = await getActionRules();
-  const current = rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
-  const upToDate =
-    current.length === ACTION_RULE_REGEXES.length &&
-    ACTION_RULE_REGEXES.every((regex) => current.includes(regex));
-  if (upToDate) return;
-
-  chrome.declarativeContent.onPageChanged.removeRules(undefined, () => {
-    chrome.declarativeContent.onPageChanged.addRules([
-      {
-        conditions: ACTION_RULE_REGEXES.map(
-          (regex) => new chrome.declarativeContent.PageStateMatcher({ pageUrl: { urlMatches: regex } })
-        ),
-        actions: [new chrome.declarativeContent.ShowAction()],
-      },
-    ]);
-  });
-}
-
-// ── Dynamic content scripts for optional sites ───────────────────────────────
-// Optional sites are not in manifest content_scripts; their scripts are
-// registered here once the user grants the host permission (see popup).
-
-let _syncQueue = Promise.resolve();
-function syncOptionalContentScripts() {
-  _syncQueue = _syncQueue.then(_doSyncOptionalContentScripts, _doSyncOptionalContentScripts);
-  return _syncQueue;
-}
-async function _doSyncOptionalContentScripts() {
-  const registered = await chrome.scripting.getRegisteredContentScripts();
-  const registeredIds = new Set(registered.map((script) => script.id));
-
-  for (const config of OPTIONAL_SITE_CONFIGS) {
-    const granted = await chrome.permissions.contains({ origins: config.matchPatterns });
-    if (granted && !registeredIds.has(config.hostname)) {
-      await chrome.scripting.registerContentScripts([
-        {
-          id: config.hostname,
-          matches: config.matchPatterns,
-          js: ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"],
-          runAt: "document_start",
-        },
-      ]);
-    } else if (!granted && registeredIds.has(config.hostname)) {
-      await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
-    }
-  }
-}
+import { SUPPORTED_SITES, extractHostname } from "./constants/site-configs.js";
+import { ensureActionRules, syncOptionalContentScripts } from "./shared/site-sync.js";
 
 // ── Serialized site-setting updates ─────────────────────────────────────────
 
@@ -96,6 +29,7 @@ function validateSiteSettingUpdates(updates) {
 // Both operations are idempotent, so run them on every service worker start
 // rather than relying on onInstalled/onStartup (which don't cover all the
 // ways rules and registrations can get out of sync, e.g. unpacked loads).
+chrome.action.disable();
 ensureActionRules();
 syncOptionalContentScripts();
 
@@ -111,14 +45,9 @@ chrome.runtime.onInstalled.addListener((details) => {
 chrome.permissions.onAdded.addListener(() => syncOptionalContentScripts());
 chrome.permissions.onRemoved.addListener(() => syncOptionalContentScripts());
 
-// Lets the popup/options page wait for registration before reloading the tab.
+// Lets the popup/options page keep working when they are not the ones syncing.
 chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
   if (sender.id !== chrome.runtime.id) return;
-
-  if (message?.type === "sync-optional-sites") {
-    syncOptionalContentScripts().then(() => sendResponse(true));
-    return true;
-  }
 
   if (message?.type === "update-site-settings") {
     const updates = validateSiteSettingUpdates(message.updates);

--- a/shared/site-sync.js
+++ b/shared/site-sync.js
@@ -1,0 +1,85 @@
+/**
+ * Site registration sync — shared by the service worker and the extension pages.
+ *
+ * Chrome keeps serving the previous service worker script after an extension
+ * update because the script URL is unchanged, so a service worker that was
+ * started before the update keeps an outdated SITE_CONFIGS in memory. Any site
+ * added by the update would then never get an action rule or a content script.
+ * Extension pages always load the current code, so the popup and the options
+ * page run this sync too and repair the state on their next open.
+ *
+ * Both functions are idempotent and safe to call from any extension context.
+ */
+import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS } from "../constants/site-configs.js";
+
+function matchPatternToRegex(pattern) {
+  return "^" + pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$";
+}
+
+const ACTION_RULE_REGEXES = SITE_CONFIGS.flatMap((config) => config.matchPatterns.map(matchPatternToRegex));
+
+function getActionRules() {
+  return new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
+}
+
+// The action is disabled by default and shown declaratively on supported sites.
+// declarativeContent needs no host access, so the icon stays clickable on
+// optional sites even before the user grants the host permission (the popup is
+// where they grant it).
+export async function ensureActionRules() {
+  const rules = await getActionRules();
+  const current = rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
+  const upToDate =
+    current.length === ACTION_RULE_REGEXES.length &&
+    ACTION_RULE_REGEXES.every((regex) => current.includes(regex));
+  if (upToDate) return;
+
+  await new Promise((resolve) =>
+    chrome.declarativeContent.onPageChanged.removeRules(undefined, () =>
+      chrome.declarativeContent.onPageChanged.addRules(
+        [
+          {
+            conditions: ACTION_RULE_REGEXES.map(
+              (regex) => new chrome.declarativeContent.PageStateMatcher({ pageUrl: { urlMatches: regex } })
+            ),
+            actions: [new chrome.declarativeContent.ShowAction()],
+          },
+        ],
+        resolve
+      )
+    )
+  );
+}
+
+// Optional sites are not in manifest content_scripts; their scripts are
+// registered here once the user grants the host permission (see popup).
+let _syncQueue = Promise.resolve();
+export function syncOptionalContentScripts() {
+  _syncQueue = _syncQueue.then(_doSyncOptionalContentScripts, _doSyncOptionalContentScripts);
+  return _syncQueue;
+}
+
+async function _doSyncOptionalContentScripts() {
+  const registered = await chrome.scripting.getRegisteredContentScripts();
+  const registeredIds = new Set(registered.map((script) => script.id));
+
+  for (const config of OPTIONAL_SITE_CONFIGS) {
+    const granted = await chrome.permissions.contains({ origins: config.matchPatterns });
+    if (granted && !registeredIds.has(config.hostname)) {
+      await chrome.scripting.registerContentScripts([
+        {
+          id: config.hostname,
+          matches: config.matchPatterns,
+          js: ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"],
+          runAt: "document_start",
+        },
+      ]);
+    } else if (!granted && registeredIds.has(config.hostname)) {
+      await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
+    }
+  }
+}
+
+export async function syncSiteRegistrations() {
+  await Promise.all([ensureActionRules(), syncOptionalContentScripts()]);
+}

--- a/shared/site-sync.js
+++ b/shared/site-sync.js
@@ -12,9 +12,10 @@
  * run this sync too. Every export is idempotent and safe to call concurrently
  * from any extension context.
  */
-import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS } from "../constants/site-configs.js";
+import { SITE_CONFIGS, SITE_CONFIGS_REVISION, OPTIONAL_SITE_CONFIGS } from "../constants/site-configs.js";
 
 const ACTION_RULE_ID = "supported-sites";
+const RULES_REVISION_KEY = "actionRulesRevision";
 const CONTENT_SCRIPT_FILES = ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"];
 const RUN_AT = "document_start";
 
@@ -60,6 +61,11 @@ async function _doEnsureActionRules() {
   const upToDate = rules.length === 1 && rules[0].id === ACTION_RULE_ID && sameMembers(current, ACTION_RULE_REGEXES);
   if (upToDate) return;
 
+  // A worker still running pre-update code would otherwise overwrite the rules
+  // an extension page already repaired with the current site list
+  const stored = await chrome.storage.local.get(RULES_REVISION_KEY);
+  if ((stored[RULES_REVISION_KEY] ?? 0) > SITE_CONFIGS_REVISION) return;
+
   // Clears both the outdated rule and the unnamed rules older versions added
   await callWithLastError((done) => chrome.declarativeContent.onPageChanged.removeRules(undefined, done));
   try {
@@ -81,7 +87,10 @@ async function _doEnsureActionRules() {
     // Tolerate another context winning the race with the same rule id
     const rulesNow = await getActionRules();
     if (!rulesNow.some((rule) => rule.id === ACTION_RULE_ID)) throw error;
+    return;
   }
+
+  await chrome.storage.local.set({ [RULES_REVISION_KEY]: SITE_CONFIGS_REVISION });
 }
 
 // ── Dynamic content scripts for optional sites ───────────────────────────────
@@ -98,10 +107,22 @@ export function syncOptionalContentScripts() {
 
 function isRegistrationCurrent(existing, script) {
   return (
+    Boolean(existing) &&
     sameMembers(existing.matches, script.matches) &&
     sameMembers(existing.js, script.js) &&
     existing.runAt === script.runAt
   );
+}
+
+// The popup and the service worker both sync on a permission grant, and their
+// queues are per-context, so a losing writer must accept the winner's result
+async function tolerateConcurrentWrite(write, isSettled) {
+  try {
+    await write();
+  } catch (error) {
+    const registered = await chrome.scripting.getRegisteredContentScripts();
+    if (!isSettled(registered)) throw error;
+  }
 }
 
 async function _doSyncOptionalContentScripts() {
@@ -117,14 +138,19 @@ async function _doSyncOptionalContentScripts() {
       js: CONTENT_SCRIPT_FILES,
       runAt: RUN_AT,
     };
+    const findSelf = (scripts) => scripts.find((s) => s.id === config.hostname);
 
-    if (granted && !existing) {
-      await chrome.scripting.registerContentScripts([script]);
-    } else if (granted && !isRegistrationCurrent(existing, script)) {
-      // Keeps a site working after its match patterns or scripts change
-      await chrome.scripting.updateContentScripts([script]);
+    if (granted && !isRegistrationCurrent(existing, script)) {
+      // updateContentScripts keeps a site working after its patterns change
+      const write = existing
+        ? () => chrome.scripting.updateContentScripts([script])
+        : () => chrome.scripting.registerContentScripts([script]);
+      await tolerateConcurrentWrite(write, (scripts) => isRegistrationCurrent(findSelf(scripts), script));
     } else if (!granted && existing) {
-      await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
+      await tolerateConcurrentWrite(
+        () => chrome.scripting.unregisterContentScripts({ ids: [config.hostname] }),
+        (scripts) => !findSelf(scripts)
+      );
     }
   }
 }

--- a/shared/site-sync.js
+++ b/shared/site-sync.js
@@ -1,16 +1,22 @@
 /**
  * Site registration sync — shared by the service worker and the extension pages.
  *
- * Chrome keeps serving the previous service worker script after an extension
- * update because the script URL is unchanged, so a service worker that was
- * started before the update keeps an outdated SITE_CONFIGS in memory. Any site
- * added by the update would then never get an action rule or a content script.
- * Extension pages always load the current code, so the popup and the options
- * page run this sync too and repair the state on their next open.
+ * An extension update can leave a service worker that was started before the
+ * update running pre-update code, because its script URL is unchanged. Such a
+ * worker holds an outdated SITE_CONFIGS, so any site added by the update gets
+ * neither an action rule nor a content script. Reproduced with unpacked
+ * updates; whether packed store updates hit the same path is unverified, so
+ * this module is written to repair the state either way.
  *
- * Both functions are idempotent and safe to call from any extension context.
+ * Extension pages always load current code, so the popup and the options page
+ * run this sync too. Every export is idempotent and safe to call concurrently
+ * from any extension context.
  */
 import { SITE_CONFIGS, OPTIONAL_SITE_CONFIGS } from "../constants/site-configs.js";
+
+const ACTION_RULE_ID = "supported-sites";
+const CONTENT_SCRIPT_FILES = ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"];
+const RUN_AT = "document_start";
 
 function matchPatternToRegex(pattern) {
   return "^" + pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$";
@@ -18,63 +24,106 @@ function matchPatternToRegex(pattern) {
 
 const ACTION_RULE_REGEXES = SITE_CONFIGS.flatMap((config) => config.matchPatterns.map(matchPatternToRegex));
 
+function sameMembers(a, b) {
+  return Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.every((value) => b.includes(value));
+}
+
+// Callback APIs report failures through lastError instead of rejecting
+function callWithLastError(invoke) {
+  return new Promise((resolve, reject) =>
+    invoke(() => (chrome.runtime.lastError ? reject(new Error(chrome.runtime.lastError.message)) : resolve()))
+  );
+}
+
 function getActionRules() {
   return new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
 }
 
+// ── Action icon visibility ───────────────────────────────────────────────────
 // The action is disabled by default and shown declaratively on supported sites.
 // declarativeContent needs no host access, so the icon stays clickable on
 // optional sites even before the user grants the host permission (the popup is
 // where they grant it).
-export async function ensureActionRules() {
+
+let _rulesQueue = Promise.resolve();
+
+export function ensureActionRules() {
+  const result = _rulesQueue.then(_doEnsureActionRules, _doEnsureActionRules);
+  // A rejected sync must not poison the next caller's queue
+  _rulesQueue = result.catch(() => { });
+  return result;
+}
+
+async function _doEnsureActionRules() {
   const rules = await getActionRules();
   const current = rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
-  const upToDate =
-    current.length === ACTION_RULE_REGEXES.length &&
-    ACTION_RULE_REGEXES.every((regex) => current.includes(regex));
+  const upToDate = rules.length === 1 && rules[0].id === ACTION_RULE_ID && sameMembers(current, ACTION_RULE_REGEXES);
   if (upToDate) return;
 
-  await new Promise((resolve) =>
-    chrome.declarativeContent.onPageChanged.removeRules(undefined, () =>
+  // Clears both the outdated rule and the unnamed rules older versions added
+  await callWithLastError((done) => chrome.declarativeContent.onPageChanged.removeRules(undefined, done));
+  try {
+    await callWithLastError((done) =>
       chrome.declarativeContent.onPageChanged.addRules(
         [
           {
+            id: ACTION_RULE_ID,
             conditions: ACTION_RULE_REGEXES.map(
               (regex) => new chrome.declarativeContent.PageStateMatcher({ pageUrl: { urlMatches: regex } })
             ),
             actions: [new chrome.declarativeContent.ShowAction()],
           },
         ],
-        resolve
+        done
       )
-    )
-  );
+    );
+  } catch (error) {
+    // Tolerate another context winning the race with the same rule id
+    const rulesNow = await getActionRules();
+    if (!rulesNow.some((rule) => rule.id === ACTION_RULE_ID)) throw error;
+  }
 }
 
+// ── Dynamic content scripts for optional sites ───────────────────────────────
 // Optional sites are not in manifest content_scripts; their scripts are
 // registered here once the user grants the host permission (see popup).
-let _syncQueue = Promise.resolve();
+
+let _scriptsQueue = Promise.resolve();
+
 export function syncOptionalContentScripts() {
-  _syncQueue = _syncQueue.then(_doSyncOptionalContentScripts, _doSyncOptionalContentScripts);
-  return _syncQueue;
+  const result = _scriptsQueue.then(_doSyncOptionalContentScripts, _doSyncOptionalContentScripts);
+  _scriptsQueue = result.catch(() => { });
+  return result;
+}
+
+function isRegistrationCurrent(existing, script) {
+  return (
+    sameMembers(existing.matches, script.matches) &&
+    sameMembers(existing.js, script.js) &&
+    existing.runAt === script.runAt
+  );
 }
 
 async function _doSyncOptionalContentScripts() {
   const registered = await chrome.scripting.getRegisteredContentScripts();
-  const registeredIds = new Set(registered.map((script) => script.id));
+  const byId = new Map(registered.map((script) => [script.id, script]));
 
   for (const config of OPTIONAL_SITE_CONFIGS) {
     const granted = await chrome.permissions.contains({ origins: config.matchPatterns });
-    if (granted && !registeredIds.has(config.hostname)) {
-      await chrome.scripting.registerContentScripts([
-        {
-          id: config.hostname,
-          matches: config.matchPatterns,
-          js: ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"],
-          runAt: "document_start",
-        },
-      ]);
-    } else if (!granted && registeredIds.has(config.hostname)) {
+    const existing = byId.get(config.hostname);
+    const script = {
+      id: config.hostname,
+      matches: config.matchPatterns,
+      js: CONTENT_SCRIPT_FILES,
+      runAt: RUN_AT,
+    };
+
+    if (granted && !existing) {
+      await chrome.scripting.registerContentScripts([script]);
+    } else if (granted && !isRegistrationCurrent(existing, script)) {
+      // Keeps a site working after its match patterns or scripts change
+      await chrome.scripting.updateContentScripts([script]);
+    } else if (!granted && existing) {
       await chrome.scripting.unregisterContentScripts({ ids: [config.hostname] });
     }
   }

--- a/tests/update-path.spec.js
+++ b/tests/update-path.spec.js
@@ -1,0 +1,120 @@
+/**
+ * Update-path regression test.
+ *
+ * Chrome keeps serving the previous service worker script when its URL is
+ * unchanged, so an extension update can leave the worker running pre-update
+ * code: sites added by the update get no action rule and no content script.
+ * v2.4.0 shipped with that defect.
+ *
+ * The guarantee this test protects is the repair path in shared/site-sync.js:
+ * extension pages always load current code, so opening the popup after an
+ * update must bring the action rules back in sync with the current manifest.
+ *
+ * The "previous version" is the current tree with its newest opt-in site
+ * removed, which reproduces the stale worker without depending on git tags.
+ */
+const { test, expect, chromium } = require("@playwright/test");
+const fs = require("fs");
+const path = require("path");
+const os = require("os");
+
+const REPO_ROOT = path.resolve(__dirname, "..");
+const PACKAGED = ["_locales", "constants", "content", "icon", "options", "popup", "shared"];
+const SITE_ENTRY = /\{ hostname: "([^"]+)", matchPatterns: \[([^\]]+)\], optional: true \},?\r?\n?/g;
+
+function copyCurrentBuild(targetDir) {
+  fs.rmSync(targetDir, { recursive: true, force: true });
+  fs.mkdirSync(targetDir, { recursive: true });
+  for (const dir of PACKAGED) {
+    fs.cpSync(path.join(REPO_ROOT, dir), path.join(targetDir, dir), { recursive: true });
+  }
+  fs.copyFileSync(path.join(REPO_ROOT, "service-worker.js"), path.join(targetDir, "service-worker.js"));
+  fs.copyFileSync(path.join(REPO_ROOT, "manifest.json"), path.join(targetDir, "manifest.json"));
+}
+
+function buildPreviousVersion(targetDir) {
+  copyCurrentBuild(targetDir);
+
+  const configPath = path.join(targetDir, "constants", "site-configs.js");
+  const configSource = fs.readFileSync(configPath, "utf-8");
+  const entries = [...configSource.matchAll(SITE_ENTRY)];
+  const newest = entries.at(-1);
+  expect(newest, "site-configs.js has no opt-in site to remove").toBeTruthy();
+
+  const patterns = newest[2].split(",").map((p) => p.trim().replace(/^"|"$/g, ""));
+  fs.writeFileSync(configPath, configSource.replace(newest[0], ""));
+
+  const manifestPath = path.join(targetDir, "manifest.json");
+  const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+  manifest.optional_host_permissions = manifest.optional_host_permissions.filter((p) => !patterns.includes(p));
+  fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
+
+  return { removedHostname: newest[1] };
+}
+
+async function withExtension(userDataDir, extensionPath, fn) {
+  const context = await chromium.launchPersistentContext(userDataDir, {
+    headless: false,
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      "--no-first-run",
+      "--disable-gpu",
+    ],
+    ignoreDefaultArgs: ["--enable-automation"],
+  });
+  try {
+    const serviceWorker = context.serviceWorkers()[0] || (await context.waitForEvent("serviceworker"));
+    return await fn(context, serviceWorker);
+  } finally {
+    await context.close();
+  }
+}
+
+function readActionRuleRegexes(serviceWorker) {
+  return serviceWorker.evaluate(async () => {
+    const rules = await new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
+    return rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
+  });
+}
+
+test("opening the popup after an update re-syncs the action rules", async () => {
+  test.setTimeout(120000);
+
+  const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), "ctrl-enter-update-"));
+  const extensionDir = fs.mkdtempSync(path.join(os.tmpdir(), "ctrl-enter-ext-"));
+
+  try {
+    const { removedHostname } = buildPreviousVersion(extensionDir);
+
+    await withExtension(userDataDir, extensionDir, (context, serviceWorker) =>
+      expect(async () => {
+        expect((await readActionRuleRegexes(serviceWorker)).length).toBeGreaterThan(0);
+      }).toPass({ timeout: 10000 })
+    );
+
+    const manifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "manifest.json"), "utf-8"));
+    const expectedPatternCount =
+      manifest.content_scripts[0].matches.length + manifest.optional_host_permissions.length;
+
+    // Same profile, same extension id and same service worker URL: an update,
+    // not a fresh install
+    copyCurrentBuild(extensionDir);
+    await withExtension(userDataDir, extensionDir, async (context, serviceWorker) => {
+      const extensionId = serviceWorker.url().split("/")[2];
+      const page = await context.newPage();
+      await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+
+      await expect(async () => {
+        const regexes = await readActionRuleRegexes(serviceWorker);
+        expect(
+          regexes.length,
+          `Action rules were not re-synced after the update (${removedHostname} is missing)`
+        ).toBe(expectedPatternCount);
+      }).toPass({ timeout: 10000 });
+    });
+  } finally {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(extensionDir, { recursive: true, force: true });
+  }
+});

--- a/tests/update-path.spec.js
+++ b/tests/update-path.spec.js
@@ -44,7 +44,10 @@ function buildPreviousVersion(targetDir) {
   expect(newest, "site-configs.js has no opt-in site to remove").toBeTruthy();
 
   const patterns = newest[2].split(",").map((pattern) => pattern.trim().replace(/^"|"$/g, ""));
-  fs.writeFileSync(configPath, configSource.replace(newest[0], ""));
+  fs.writeFileSync(
+    configPath,
+    configSource.replace(newest[0], "").replace(/SITE_CONFIGS_REVISION = \d+/, "SITE_CONFIGS_REVISION = 0")
+  );
 
   const manifestPath = path.join(targetDir, "manifest.json");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));

--- a/tests/update-path.spec.js
+++ b/tests/update-path.spec.js
@@ -1,10 +1,10 @@
 /**
  * Update-path regression test.
  *
- * Chrome keeps serving the previous service worker script when its URL is
- * unchanged, so an extension update can leave the worker running pre-update
- * code: sites added by the update get no action rule and no content script.
- * v2.4.0 shipped with that defect.
+ * An extension update can leave a service worker that was started before the
+ * update running pre-update code, because its script URL is unchanged: sites
+ * added by the update then get no action rule and no content script. v2.4.0
+ * shipped with that defect.
  *
  * The guarantee this test protects is the repair path in shared/site-sync.js:
  * extension pages always load current code, so opening the popup after an
@@ -19,17 +19,20 @@ const path = require("path");
 const os = require("os");
 
 const REPO_ROOT = path.resolve(__dirname, "..");
-const PACKAGED = ["_locales", "constants", "content", "icon", "options", "popup", "shared"];
+const PACKAGED_DIRS = ["_locales", "constants", "content", "icon", "options", "popup", "shared"];
+const PACKAGED_FILES = ["service-worker.js", "manifest.json"];
 const SITE_ENTRY = /\{ hostname: "([^"]+)", matchPatterns: \[([^\]]+)\], optional: true \},?\r?\n?/g;
+const ACTION_RULE_ID = "supported-sites";
 
 function copyCurrentBuild(targetDir) {
   fs.rmSync(targetDir, { recursive: true, force: true });
   fs.mkdirSync(targetDir, { recursive: true });
-  for (const dir of PACKAGED) {
+  for (const dir of PACKAGED_DIRS) {
     fs.cpSync(path.join(REPO_ROOT, dir), path.join(targetDir, dir), { recursive: true });
   }
-  fs.copyFileSync(path.join(REPO_ROOT, "service-worker.js"), path.join(targetDir, "service-worker.js"));
-  fs.copyFileSync(path.join(REPO_ROOT, "manifest.json"), path.join(targetDir, "manifest.json"));
+  for (const file of PACKAGED_FILES) {
+    fs.copyFileSync(path.join(REPO_ROOT, file), path.join(targetDir, file));
+  }
 }
 
 function buildPreviousVersion(targetDir) {
@@ -37,16 +40,17 @@ function buildPreviousVersion(targetDir) {
 
   const configPath = path.join(targetDir, "constants", "site-configs.js");
   const configSource = fs.readFileSync(configPath, "utf-8");
-  const entries = [...configSource.matchAll(SITE_ENTRY)];
-  const newest = entries.at(-1);
+  const newest = [...configSource.matchAll(SITE_ENTRY)].at(-1);
   expect(newest, "site-configs.js has no opt-in site to remove").toBeTruthy();
 
-  const patterns = newest[2].split(",").map((p) => p.trim().replace(/^"|"$/g, ""));
+  const patterns = newest[2].split(",").map((pattern) => pattern.trim().replace(/^"|"$/g, ""));
   fs.writeFileSync(configPath, configSource.replace(newest[0], ""));
 
   const manifestPath = path.join(targetDir, "manifest.json");
   const manifest = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
   manifest.optional_host_permissions = manifest.optional_host_permissions.filter((p) => !patterns.includes(p));
+  // A real update also bumps the version
+  manifest.version = "0.0.1";
   fs.writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
 
   return { removedHostname: newest[1] };
@@ -64,17 +68,21 @@ async function withExtension(userDataDir, extensionPath, fn) {
     ignoreDefaultArgs: ["--enable-automation"],
   });
   try {
-    const serviceWorker = context.serviceWorkers()[0] || (await context.waitForEvent("serviceworker"));
-    return await fn(context, serviceWorker);
+    return await fn(context);
   } finally {
     await context.close();
   }
 }
 
-function readActionRuleRegexes(serviceWorker) {
-  return serviceWorker.evaluate(async () => {
+// Reads from an extension page so the assertion does not depend on whether the
+// service worker happens to be running
+function readActionRules(page) {
+  return page.evaluate(async () => {
     const rules = await new Promise((resolve) => chrome.declarativeContent.onPageChanged.getRules(resolve));
-    return rules.flatMap((rule) => rule.conditions.map((c) => c.pageUrl?.urlMatches));
+    return rules.map((rule) => ({
+      id: rule.id,
+      regexes: rule.conditions.map((condition) => condition.pageUrl?.urlMatches),
+    }));
   });
 }
 
@@ -87,11 +95,25 @@ test("opening the popup after an update re-syncs the action rules", async () => 
   try {
     const { removedHostname } = buildPreviousVersion(extensionDir);
 
-    await withExtension(userDataDir, extensionDir, (context, serviceWorker) =>
-      expect(async () => {
-        expect((await readActionRuleRegexes(serviceWorker)).length).toBeGreaterThan(0);
-      }).toPass({ timeout: 10000 })
-    );
+    const extensionId = await withExtension(userDataDir, extensionDir, async (context) => {
+      const serviceWorker = context.serviceWorkers()[0] || (await context.waitForEvent("serviceworker"));
+      const id = serviceWorker.url().split("/")[2];
+      const page = await context.newPage();
+      await page.goto(`chrome-extension://${id}/popup/popup.html`);
+
+      await expect(async () => {
+        const rules = await readActionRules(page);
+        expect(rules.flatMap((rule) => rule.regexes).length).toBeGreaterThan(0);
+      }).toPass({ timeout: 10000 });
+
+      const regexes = (await readActionRules(page)).flatMap((rule) => rule.regexes);
+      expect(
+        regexes.some((regex) => regex.includes(removedHostname.replace(/\./g, "\\."))),
+        `the previous version must not already know ${removedHostname}`
+      ).toBe(false);
+
+      return id;
+    });
 
     const manifest = JSON.parse(fs.readFileSync(path.join(REPO_ROOT, "manifest.json"), "utf-8"));
     const expectedPatternCount =
@@ -100,17 +122,19 @@ test("opening the popup after an update re-syncs the action rules", async () => 
     // Same profile, same extension id and same service worker URL: an update,
     // not a fresh install
     copyCurrentBuild(extensionDir);
-    await withExtension(userDataDir, extensionDir, async (context, serviceWorker) => {
-      const extensionId = serviceWorker.url().split("/")[2];
+    await withExtension(userDataDir, extensionDir, async (context) => {
       const page = await context.newPage();
       await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
 
       await expect(async () => {
-        const regexes = await readActionRuleRegexes(serviceWorker);
+        const rules = await readActionRules(page);
+        expect(rules.length, "the action rules must not be duplicated").toBe(1);
+        expect(rules[0].id).toBe(ACTION_RULE_ID);
         expect(
-          regexes.length,
-          `Action rules were not re-synced after the update (${removedHostname} is missing)`
-        ).toBe(expectedPatternCount);
+          rules[0].regexes.some((regex) => regex.includes(removedHostname.replace(/\./g, "\\."))),
+          `${removedHostname} was not re-synced after the update`
+        ).toBe(true);
+        expect(rules[0].regexes.length).toBe(expectedPatternCount);
       }).toPass({ timeout: 10000 });
     });
   } finally {

--- a/tools/site-sync.test.js
+++ b/tools/site-sync.test.js
@@ -1,0 +1,165 @@
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+
+const siteSyncPath = path.join(__dirname, "..", "shared", "site-sync.js");
+const siteConfigsPath = path.join(__dirname, "..", "constants", "site-configs.js");
+const contentScriptFiles = ["content/ctrl-enter-utils.js", "content/ctrl-enter-handler.js"];
+
+// The extension ships ES modules but package.json declares commonjs, so the
+// sources are imported as data URLs, which are always treated as modules
+function toDataUrl(source) {
+  return "data:text/javascript;base64," + Buffer.from(source, "utf8").toString("base64");
+}
+
+// Each test needs its own module instance because the queues are module state
+async function loadSiteSync() {
+  const configsUrl = toDataUrl(fs.readFileSync(siteConfigsPath, "utf8"));
+  const source = fs
+    .readFileSync(siteSyncPath, "utf8")
+    .replace("../constants/site-configs.js", configsUrl)
+    .concat(`\n// ${Math.random()}\n`);
+  const [siteSync, configs] = await Promise.all([import(toDataUrl(source)), import(configsUrl)]);
+  return { ...siteSync, ...configs };
+}
+
+function createChrome({ rules = [], registered = [], granted = [] } = {}) {
+  const calls = { removeRules: 0, addRules: [], register: [], update: [], unregister: [] };
+  let currentRules = rules;
+
+  globalThis.chrome = {
+    runtime: { lastError: null },
+    declarativeContent: {
+      PageStateMatcher: class {
+        constructor(options) {
+          Object.assign(this, options);
+        }
+      },
+      ShowAction: class { },
+      onPageChanged: {
+        getRules: (callback) => callback(currentRules),
+        removeRules: (ids, callback) => {
+          calls.removeRules += 1;
+          currentRules = [];
+          callback();
+        },
+        addRules: (added, callback) => {
+          calls.addRules.push(...added);
+          currentRules = currentRules.concat(added);
+          callback();
+        },
+      },
+    },
+    permissions: {
+      contains: async ({ origins }) => origins.every((origin) => granted.includes(origin)),
+    },
+    scripting: {
+      getRegisteredContentScripts: async () => registered,
+      registerContentScripts: async (scripts) => calls.register.push(...scripts),
+      updateContentScripts: async (scripts) => calls.update.push(...scripts),
+      unregisterContentScripts: async ({ ids }) => calls.unregister.push(...ids),
+    },
+  };
+
+  return { calls, getRules: () => currentRules };
+}
+
+function toRuleRegex(pattern) {
+  return "^" + pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*") + "$";
+}
+
+test("古いルールは固定 ID の単一ルールに置き換えられる", async () => {
+  const { calls } = createChrome({
+    rules: [{ id: "legacy", conditions: [{ pageUrl: { urlMatches: "^https://chatgpt\\.com/.*$" } }] }],
+  });
+  const { ensureActionRules, SITE_CONFIGS } = await loadSiteSync();
+
+  await ensureActionRules();
+
+  assert.equal(calls.removeRules, 1);
+  assert.equal(calls.addRules.length, 1);
+  assert.equal(calls.addRules[0].id, "supported-sites");
+
+  const registered = calls.addRules[0].conditions.map((condition) => condition.pageUrl.urlMatches);
+  const expected = SITE_CONFIGS.flatMap((config) => config.matchPatterns.map(toRuleRegex));
+  assert.deepEqual(registered.slice().sort(), expected.slice().sort());
+});
+
+test("ルールが最新なら書き換えない", async () => {
+  const { ensureActionRules, SITE_CONFIGS } = await loadSiteSync();
+  const conditions = SITE_CONFIGS.flatMap((config) =>
+    config.matchPatterns.map((pattern) => ({ pageUrl: { urlMatches: toRuleRegex(pattern) } }))
+  );
+  const { calls } = createChrome({ rules: [{ id: "supported-sites", conditions }] });
+
+  await ensureActionRules();
+
+  assert.equal(calls.removeRules, 0);
+  assert.equal(calls.addRules.length, 0);
+});
+
+test("同時に呼ばれてもルールは重複しない", async () => {
+  const { getRules } = createChrome({ rules: [{ id: "legacy", conditions: [] }] });
+  const { ensureActionRules } = await loadSiteSync();
+
+  await Promise.all([ensureActionRules(), ensureActionRules(), ensureActionRules()]);
+
+  assert.equal(getRules().length, 1);
+  assert.equal(getRules()[0].id, "supported-sites");
+});
+
+test("許可済みの opt-in サイトはコンテンツスクリプトが登録される", async () => {
+  const { syncOptionalContentScripts, OPTIONAL_SITE_CONFIGS } = await loadSiteSync();
+  const target = OPTIONAL_SITE_CONFIGS.at(-1);
+  const { calls } = createChrome({ granted: target.matchPatterns });
+
+  await syncOptionalContentScripts();
+
+  assert.deepEqual(calls.register.map((script) => script.id), [target.hostname]);
+  assert.deepEqual(calls.register[0].matches, target.matchPatterns);
+  assert.deepEqual(calls.register[0].js, contentScriptFiles);
+  assert.equal(calls.register[0].runAt, "document_start");
+});
+
+test("登録済みでも match パターンが古ければ更新される", async () => {
+  const { syncOptionalContentScripts, OPTIONAL_SITE_CONFIGS } = await loadSiteSync();
+  const target = OPTIONAL_SITE_CONFIGS.at(-1);
+  const { calls } = createChrome({
+    granted: target.matchPatterns,
+    registered: [
+      { id: target.hostname, matches: ["https://outdated.example/*"], js: contentScriptFiles, runAt: "document_start" },
+    ],
+  });
+
+  await syncOptionalContentScripts();
+
+  assert.equal(calls.register.length, 0);
+  assert.deepEqual(calls.update.map((script) => script.id), [target.hostname]);
+  assert.deepEqual(calls.update[0].matches, target.matchPatterns);
+});
+
+test("許可が取り消されたサイトは登録解除される", async () => {
+  const { syncOptionalContentScripts, OPTIONAL_SITE_CONFIGS } = await loadSiteSync();
+  const target = OPTIONAL_SITE_CONFIGS.at(-1);
+  const { calls } = createChrome({
+    registered: [
+      { id: target.hostname, matches: target.matchPatterns, js: contentScriptFiles, runAt: "document_start" },
+    ],
+  });
+
+  await syncOptionalContentScripts();
+
+  assert.deepEqual(calls.unregister, [target.hostname]);
+});
+
+test("未許可のサイトには何も登録しない", async () => {
+  const { syncOptionalContentScripts } = await loadSiteSync();
+  const { calls } = createChrome();
+
+  await syncOptionalContentScripts();
+
+  assert.equal(calls.register.length, 0);
+  assert.equal(calls.update.length, 0);
+  assert.equal(calls.unregister.length, 0);
+});

--- a/tools/site-sync.test.js
+++ b/tools/site-sync.test.js
@@ -24,12 +24,19 @@ async function loadSiteSync() {
   return { ...siteSync, ...configs };
 }
 
-function createChrome({ rules = [], registered = [], granted = [] } = {}) {
+function createChrome({ rules = [], registered = [], granted = [], storage = {}, failWrites = false } = {}) {
   const calls = { removeRules: 0, addRules: [], register: [], update: [], unregister: [] };
   let currentRules = rules;
+  let currentScripts = registered;
 
   globalThis.chrome = {
     runtime: { lastError: null },
+    storage: {
+      local: {
+        get: async (key) => (key in storage ? { [key]: storage[key] } : {}),
+        set: async (values) => Object.assign(storage, values),
+      },
+    },
     declarativeContent: {
       PageStateMatcher: class {
         constructor(options) {
@@ -55,14 +62,32 @@ function createChrome({ rules = [], registered = [], granted = [] } = {}) {
       contains: async ({ origins }) => origins.every((origin) => granted.includes(origin)),
     },
     scripting: {
-      getRegisteredContentScripts: async () => registered,
-      registerContentScripts: async (scripts) => calls.register.push(...scripts),
-      updateContentScripts: async (scripts) => calls.update.push(...scripts),
-      unregisterContentScripts: async ({ ids }) => calls.unregister.push(...ids),
+      getRegisteredContentScripts: async () => currentScripts,
+      registerContentScripts: async (scripts) => {
+        calls.register.push(...scripts);
+        if (failWrites) throw new Error("Duplicate script ID");
+        currentScripts = currentScripts.concat(scripts);
+      },
+      updateContentScripts: async (scripts) => {
+        calls.update.push(...scripts);
+        if (failWrites) throw new Error("Duplicate script ID");
+      },
+      unregisterContentScripts: async ({ ids }) => {
+        calls.unregister.push(...ids);
+        if (failWrites) throw new Error("Nonexistent script ID");
+        currentScripts = currentScripts.filter((script) => !ids.includes(script.id));
+      },
     },
   };
 
-  return { calls, getRules: () => currentRules };
+  return {
+    calls,
+    storage,
+    getRules: () => currentRules,
+    setScripts: (scripts) => {
+      currentScripts = scripts;
+    },
+  };
 }
 
 function toRuleRegex(pattern) {
@@ -162,4 +187,54 @@ test("未許可のサイトには何も登録しない", async () => {
   assert.equal(calls.register.length, 0);
   assert.equal(calls.update.length, 0);
   assert.equal(calls.unregister.length, 0);
+});
+
+test("新しい世代が書いたルールを古いコードは上書きしない", async () => {
+  const { ensureActionRules, SITE_CONFIGS_REVISION } = await loadSiteSync();
+  const { calls, getRules } = createChrome({
+    rules: [{ id: "supported-sites", conditions: [{ pageUrl: { urlMatches: "^https://newer\\.example/.*$" } }] }],
+    storage: { actionRulesRevision: SITE_CONFIGS_REVISION + 1 },
+  });
+
+  await ensureActionRules();
+
+  assert.equal(calls.removeRules, 0);
+  assert.equal(calls.addRules.length, 0);
+  assert.equal(getRules()[0].conditions[0].pageUrl.urlMatches, "^https://newer\\.example/.*$");
+});
+
+test("ルールを書いたら世代番号を記録する", async () => {
+  const { ensureActionRules, SITE_CONFIGS_REVISION } = await loadSiteSync();
+  const { storage } = createChrome({ rules: [{ id: "legacy", conditions: [] }] });
+
+  await ensureActionRules();
+
+  assert.equal(storage.actionRulesRevision, SITE_CONFIGS_REVISION);
+});
+
+test("他コンテキストが先に登録していれば失敗扱いにしない", async () => {
+  const { syncOptionalContentScripts, OPTIONAL_SITE_CONFIGS } = await loadSiteSync();
+  const target = OPTIONAL_SITE_CONFIGS.at(-1);
+  const winner = {
+    id: target.hostname,
+    matches: target.matchPatterns,
+    js: contentScriptFiles,
+    runAt: "document_start",
+  };
+  const { setScripts } = createChrome({ granted: target.matchPatterns, failWrites: true });
+  // The winning context registers between our read and our write
+  globalThis.chrome.scripting.registerContentScripts = async () => {
+    setScripts([winner]);
+    throw new Error("Duplicate script ID");
+  };
+
+  await assert.doesNotReject(() => syncOptionalContentScripts());
+});
+
+test("登録に失敗し状態も直っていなければ例外にする", async () => {
+  const { syncOptionalContentScripts, OPTIONAL_SITE_CONFIGS } = await loadSiteSync();
+  const target = OPTIONAL_SITE_CONFIGS.at(-1);
+  createChrome({ granted: target.matchPatterns, failWrites: true });
+
+  await assert.rejects(() => syncOptionalContentScripts(), /Duplicate script ID/);
 });


### PR DESCRIPTION
Closes #146 (Kimi did not work for anyone updating from a previous version)

## Problem

Kimi was added in 2.4.0 as an opt-in site, but it did not work after updating from 2.3.1: the extension icon stayed disabled on the site, and the content script was never registered even after granting the host permission.

The cause is that an extension update can leave a service worker that was started before the update running pre-update code, because its script URL is unchanged. Such a worker holds an outdated `SITE_CONFIGS`, so `ensureActionRules()` and `syncOptionalContentScripts()` never learn about the new site. Reproduced with unpacked updates; the packed store update path is not verified.

Worse, the stale worker re-ran that sync on every start, so it also reverted the state after it had been repaired — which is why the site appeared to work briefly and then broke again.

## Changes

- Move the sync into `shared/site-sync.js` and run it from the popup and the options page as well. Extension pages always load current code, so opening the popup repairs an install whose worker is stale.
- Grant flows register the content script directly instead of asking the service worker to do it.
- Record the `SITE_CONFIGS_REVISION` that wrote the action rules and skip the write when a newer revision is already stored, so a stale worker cannot revert a newer sync.
- Give the action rule a fixed id and surface `lastError`, so concurrent syncs cannot duplicate or silently drop it. A write that fails because another context already produced the wanted state is treated as success.
- Re-register content scripts whose `matches`, `js` or `runAt` drifted, not just missing ones.
- Rename `background.js` to `service-worker.js`. The new URL makes existing installs pick up the new script instead of keeping the stale one. This is a one-time measure, not a per-release requirement.

No permission changes, so the update installs silently for existing users, and the "icon only lights up on supported sites" behaviour is unchanged.

## Tests

- `tools/site-sync.test.js`: 11 unit tests covering rule replacement, the revision guard, concurrent writes, and content-script register/update/unregister
- `tests/update-path.spec.js`: installs a build without the newest opt-in site, updates the same profile in place, and asserts that opening the popup restores the rule for that site. Fails without the repair path.
- `retries: 2` on CI, where service worker startup waits are timing sensitive

`npm test` (38 unit / 24 integration) and `python tools/check_supported_sites.py` pass.