### PR TITLE
Add daily supported-site URL monitoring

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Check supported-site consistency
         run: python3 tools/check_supported_sites.py
 
+      - name: Test site URL monitor
+        run: python3 -m unittest tools/test_check_site_urls.py
+
       - name: Run deterministic tests
         run: xvfb-run --auto-servernum npm test
 

--- a/.github/workflows/site-url-monitor.yml
+++ b/.github/workflows/site-url-monitor.yml
@@ -1,0 +1,57 @@
+name: Site URL Monitor
+
+on:
+  schedule:
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: site-url-monitor
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      # actions/checkout v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
+
+      - name: Check supported site URLs
+        id: site-check
+        continue-on-error: true
+        run: python3 tools/check_site_urls.py --output site-url-report.md
+
+      - name: Create, update, or close the tracking issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          CHECK_OUTCOME: ${{ steps.site-check.outcome }}
+        run: |
+          title="[Site Monitor] Supported site URL check failed"
+          issue_number=$(gh issue list \
+            --state open \
+            --limit 100 \
+            --json number,title \
+            --jq ".[] | select(.title == \"$title\") | .number" \
+            | head -n 1)
+
+          if [ "$CHECK_OUTCOME" = "failure" ]; then
+            if [ -n "$issue_number" ]; then
+              gh issue edit "$issue_number" --body-file site-url-report.md
+            else
+              gh issue create --title "$title" --body-file site-url-report.md
+            fi
+          elif [ -n "$issue_number" ]; then
+            gh issue close "$issue_number" --comment "The daily URL check is passing again."
+          fi
+
+      - name: Fail the workflow when a site needs attention
+        if: steps.site-check.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,5 +39,8 @@ jobs:
       - name: Check supported-site consistency
         run: python3 tools/check_supported_sites.py
 
+      - name: Test site URL monitor
+        run: python3 -m unittest tools/test_check_site_urls.py
+
       - name: Run deterministic tests
         run: xvfb-run --auto-servernum npm test

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,21 @@ the repository test environment. Live-site failures are diagnostic and are not a
 release gate because authentication, bot detection, and site DOM changes are
 outside this extension's control.
 
+## Site URL Monitoring
+
+The `Site URL Monitor` workflow checks every configured hostname once a day. It
+follows redirects and opens one tracking issue when a site moves to an
+unexpected hostname or cannot be reached after two attempts. The same issue is
+updated on later failures and closed automatically after recovery.
+
+HTTP 401, 403 and 404 responses still count as reachable because many supported
+sites block automated clients. This monitor detects hostname moves and outages;
+it does not prove that the chat input selectors still work. Run it locally with:
+
+```shell
+python tools/check_site_urls.py --output site-url-report.md
+```
+
 ## Releasing
 
 The version lives in `manifest.json`, `package.json` and `package-lock.json`, and

--- a/tools/check_site_urls.py
+++ b/tools/check_site_urls.py
@@ -1,0 +1,159 @@
+import argparse
+import json
+import re
+import socket
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.parse import urlparse
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SITE_CONFIGS_PATH = REPO_ROOT / "constants" / "site-configs.js"
+USER_AGENT = "Mozilla/5.0 (compatible; ChatGPT-Ctrl-Enter-Sender-Site-Monitor/1.0)"
+TIMEOUT_SECONDS = 20
+ATTEMPTS = 2
+
+ALLOWED_EXTERNAL_REDIRECTS = {
+    "notebook.google.com": {"accounts.google.com"},
+}
+
+
+@dataclass
+class ProbeResult:
+    status: int
+    final_url: str
+    redirect_hosts: list[str]
+
+
+@dataclass
+class CheckResult:
+    hostname: str
+    healthy: bool
+    detail: str
+
+
+def extract_hostnames(source):
+    return re.findall(r'hostname:\s*"([^"]+)"', source)
+
+
+def normalized_hostname(url):
+    return (urlparse(url).hostname or "").lower().rstrip(".")
+
+
+def display_url(url):
+    parsed = urlparse(url)
+    return f"{parsed.scheme}://{parsed.netloc}{parsed.path}"
+
+
+class RecordingRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def __init__(self):
+        super().__init__()
+        self.redirect_hosts = []
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        hostname = normalized_hostname(newurl)
+        if hostname:
+            self.redirect_hosts.append(hostname)
+        return super().redirect_request(req, fp, code, msg, headers, newurl)
+
+
+def probe(hostname):
+    handler = RecordingRedirectHandler()
+    opener = urllib.request.build_opener(handler)
+    request = urllib.request.Request(
+        f"https://{hostname}/",
+        headers={"User-Agent": USER_AGENT, "Accept": "text/html,*/*;q=0.8"},
+    )
+
+    try:
+        with opener.open(request, timeout=TIMEOUT_SECONDS) as response:
+            return ProbeResult(response.status, response.geturl(), handler.redirect_hosts)
+    except urllib.error.HTTPError as error:
+        # 401/403/404 still prove that the configured host is serving traffic.
+        return ProbeResult(error.code, error.geturl(), handler.redirect_hosts)
+
+
+def classify(hostname, result):
+    allowed = {hostname, *ALLOWED_EXTERNAL_REDIRECTS.get(hostname, set())}
+    unexpected = []
+    for redirected_hostname in result.redirect_hosts:
+        if redirected_hostname not in allowed and redirected_hostname not in unexpected:
+            unexpected.append(redirected_hostname)
+
+    if unexpected:
+        hosts = ", ".join(f"`{host}`" for host in unexpected)
+        return CheckResult(hostname, False, f"redirected through unexpected host(s): {hosts}")
+
+    return CheckResult(
+        hostname,
+        True,
+        f"HTTP {result.status}; final URL `{display_url(result.final_url)}`",
+    )
+
+
+def check_hostname(hostname, probe_func=probe):
+    errors = []
+    for _ in range(ATTEMPTS):
+        try:
+            return classify(hostname, probe_func(hostname))
+        except (OSError, socket.timeout, urllib.error.URLError) as error:
+            errors.append(str(error))
+
+    return CheckResult(hostname, False, f"unreachable after {ATTEMPTS} attempts: {errors[-1]}")
+
+
+def render_report(results):
+    failures = [result for result in results if not result.healthy]
+    summary = (
+        "The daily URL check found a configured host that may have moved or become unreachable."
+        if failures
+        else "All configured hosts passed the daily URL check."
+    )
+    lines = [
+        "## Supported site URL monitor",
+        "",
+        summary,
+        "HTTP 401/403/404 responses are treated as reachable; unexpected cross-host redirects are not.",
+        "",
+        "| Configured host | Result | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        state = "FAIL" if not result.healthy else "OK"
+        lines.append(f"| `{result.hostname}` | {state} | {result.detail} |")
+
+    lines.extend([
+        "",
+        f"Failures: **{len(failures)}** / {len(results)}",
+        "",
+        "Please verify the destination in a browser before changing extension permissions or selectors.",
+    ])
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Check supported site hostnames for moves and reachability")
+    parser.add_argument("--output", type=Path, help="Write a Markdown report to this path")
+    args = parser.parse_args(argv)
+
+    hostnames = extract_hostnames(SITE_CONFIGS_PATH.read_text(encoding="utf-8"))
+    if not hostnames:
+        print("No supported hostnames found", file=sys.stderr)
+        return 2
+
+    results = [check_hostname(hostname) for hostname in hostnames]
+    report = render_report(results)
+    if args.output:
+        args.output.write_text(report, encoding="utf-8")
+
+    failures = [result for result in results if not result.healthy]
+    print(json.dumps({"checked": len(results), "failures": len(failures)}))
+    for result in failures:
+        print(f"FAIL {result.hostname}: {result.detail}", file=sys.stderr)
+    return 1 if failures else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/test_check_site_urls.py
+++ b/tools/test_check_site_urls.py
@@ -1,0 +1,64 @@
+import unittest
+import urllib.error
+
+from tools.check_site_urls import CheckResult, ProbeResult, check_hostname, classify, display_url, extract_hostnames, render_report
+
+
+class SiteUrlMonitorTests(unittest.TestCase):
+    def test_extracts_hostnames_from_site_configs(self):
+        source = '''
+          { hostname: "chatgpt.com", matchPatterns: ["https://chatgpt.com/*"] },
+          { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"], optional: true },
+        '''
+        self.assertEqual(extract_hostnames(source), ["chatgpt.com", "duck.ai"])
+
+    def test_same_host_redirect_is_healthy_even_with_forbidden_status(self):
+        result = ProbeResult(403, "https://poe.com/login", ["poe.com"])
+        classified = classify("poe.com", result)
+        self.assertTrue(classified.healthy)
+
+    def test_unexpected_redirect_host_is_reported(self):
+        result = ProbeResult(200, "https://new.example/", ["new.example"])
+        classified = classify("old.example", result)
+        self.assertFalse(classified.healthy)
+        self.assertIn("new.example", classified.detail)
+
+    def test_notebook_google_login_redirect_is_allowed(self):
+        result = ProbeResult(
+            200,
+            "https://accounts.google.com/signin",
+            ["accounts.google.com"],
+        )
+        classified = classify("notebook.google.com", result)
+        self.assertTrue(classified.healthy)
+
+    def test_display_url_omits_query_and_fragment(self):
+        self.assertEqual(
+            display_url("https://accounts.google.com/signin?token=example#step"),
+            "https://accounts.google.com/signin",
+        )
+
+    def test_network_failure_is_retried(self):
+        attempts = 0
+
+        def failing_probe(_hostname):
+            nonlocal attempts
+            attempts += 1
+            raise urllib.error.URLError("temporary failure")
+
+        result = check_hostname("example.com", failing_probe)
+        self.assertEqual(attempts, 2)
+        self.assertFalse(result.healthy)
+        self.assertIn("after 2 attempts", result.detail)
+
+    def test_report_includes_failure_count(self):
+        report = render_report([
+            CheckResult("ok.example", True, "HTTP 200"),
+            CheckResult("moved.example", False, "unexpected redirect"),
+        ])
+        self.assertIn("Failures: **1** / 2", report)
+        self.assertIn("`moved.example` | FAIL", report)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- check all configured site hostnames once a day and detect unexpected cross-host redirects
- create or update one tracking issue on failure, then close it automatically after recovery
- tolerate anti-bot HTTP responses and the expected NotebookLM Google sign-in redirect
- add deterministic monitor tests to CI and document the monitor's scope

## Validation
- `python -m unittest tools/test_check_site_urls.py` (7 passed)
- `python tools/check_site_urls.py` (18 checked, 0 failures)
- confirmed `notebooklm.google.com` is detected redirecting to `notebook.google.com`
- `npm test` (51 unit, 26 integration passed)
- `python tools/check_supported_sites.py`