### PR TITLE
Hotfix permission escalation in v2.5.2

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,22 +23,19 @@ These sites may be removed if they become unmaintainable:
 
 ## How New Sites Are Shipped
 
-Chrome only disables an extension on update when the permission WARNING text
-changes, not whenever a host is added. This extension already sits at the
-"many websites" warning, so one more host does not trigger re-approval, and
-`tests/permission-warnings.spec.js` fails if a change ever would.
+Adding a required host permission disables the extension on update until the
+user approves it, even when Chrome displays the same warning text before and
+after the update. `tests/permission-warnings.spec.js` therefore rejects both
+new warning text and any required host absent from the published baseline.
 
-That leaves the choice to what serves users, rather than what is safe to ship:
+- **Required** only when the host already exists in the published manifest.
+- **Opt-in** for every new host pattern, including a replacement hostname for
+  an existing service. These sites are listed in `optional_host_permissions`,
+  marked `optional: true` in `constants/site-configs.js`, and enabled from the
+  popup.
 
-- **Required** for a widely used chat service that most users would want. It
-  works with no setup, which is one less way for the extension to look broken.
-- **Opt-in** for agent or IDE tooling and anything niche, so users who will
-  never open it are not asked for access to it. These sites are listed in
-  `optional_host_permissions`, marked `optional: true` in
-  `constants/site-configs.js`, and enabled from the popup.
-
-Anything needing a broad pattern such as `<all_urls>` stays opt-in, since that
-does raise the warning level.
+Agent or IDE tooling, niche sites, and broad patterns such as `<all_urls>` also
+stay opt-in.
 
 See the checklist in `constants/site-configs.js` for the exact steps.
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ You can use this extension on the following pages:
 * <https://grok.com>
 * <https://www.perplexity.ai>
 * <https://chat.mistral.ai>
-* <https://notebook.google.com>
+* <https://notebook.google.com> (opt-in)
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://www.kimi.com>
+* <https://www.kimi.com> (opt-in)
 * <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
 
-*Opt-in sites are agent or niche services, so access is requested only when you choose to enable them. Open the site, click the extension icon, and press "Enable on this site" once. After the first installation, the settings page opens once to introduce these sites.*
+*Opt-in sites request access only when you choose to enable them. This prevents an update from disabling the extension when support needs a new hostname. Open the site, click the extension icon, and press "Enable on this site" once. After the first installation, the settings page opens once to introduce these sites.*
 
 ## Demo Video
 

--- a/README_CH.md
+++ b/README_CH.md
@@ -34,17 +34,17 @@
 * <https://grok.com>
 * <https://www.perplexity.ai>
 * <https://chat.mistral.ai>
-* <https://notebook.google.com>
+* <https://notebook.google.com> (opt-in)
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://www.kimi.com>
+* <https://www.kimi.com> (opt-in)
 * <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
 
-*可选站点属于智能体、IDE 工具或较小众的服务，因此仅在您选择启用时请求访问权限。打开站点，点击扩展图标，然后按一次 "Enable on this site"。首次安装后，设置页面会打开一次以介绍这些站点。*
+*可选站点仅在您选择启用时请求访问权限。这可防止因支持新主机名而导致扩展在更新后被停用。打开站点，点击扩展图标，然后按一次 "Enable on this site"。首次安装后，设置页面会打开一次以介绍这些站点。*
 
 ## 演示视频
 

--- a/README_JA.md
+++ b/README_JA.md
@@ -34,17 +34,17 @@
 * <https://grok.com>
 * <https://www.perplexity.ai>
 * <https://chat.mistral.ai>
-* <https://notebook.google.com>
+* <https://notebook.google.com> (opt-in)
 * <https://github.com> (Copilot, Spark)
 * <https://poe.com>
 * <https://v0.app>
-* <https://www.kimi.com>
+* <https://www.kimi.com> (opt-in)
 * <https://cursor.com/agents> (opt-in)
 * <https://www.genspark.ai> (opt-in)
 * <https://duck.ai> (opt-in)
 * <https://manus.im> (opt-in)
 
-*オプトイン サイトはエージェント系・ニッチなサービスのため、利用者が有効化を選んだ場合にのみアクセス権限を求めます。サイトを開いて拡張機能のアイコンをクリックし、「Enable on this site」を一度押してください。初回インストール時には、これらを案内する設定ページが一度だけ開きます。*
+*オプトイン サイトは、利用者が有効化を選んだ場合にのみアクセス権限を求めます。新しいホスト名への対応を追加した更新で拡張機能が無効化されるのを防ぐためです。サイトを開いて拡張機能のアイコンをクリックし、「Enable on this site」を一度押してください。初回インストール時には、これらを案内する設定ページが一度だけ開きます。*
 
 ## デモ動画
 

--- a/constants/site-configs.js
+++ b/constants/site-configs.js
@@ -13,12 +13,10 @@
  *     registered dynamically by shared/site-sync.js.
  *
  * Which kind to use:
- *   - A widely used chat service that most users would want -> required, so it
- *     works with no setup
- *   - Agent or IDE tooling, or anything niche -> optional, so users who will
- *     never open it are not asked for access to it
- *   - Anything needing a broad pattern -> optional, since that can raise the
- *     warning level
+ *   - Existing required host from the published manifest -> required
+ *   - Any new host pattern -> optional, because adding a required host disables
+ *     the extension on update even when Chrome displays the same warning text
+ *   - Agent or IDE tooling, niche sites, and broad patterns -> optional
  *
  * When adding a new site:
  *   1. Add an entry here (hostname + matchPatterns, plus `optional: true` if
@@ -32,7 +30,7 @@
 // Generation marker for the site list. shared/site-sync.js records the highest
 // revision that wrote the action rules, so a service worker left running
 // pre-update code cannot overwrite a newer sync with its outdated list.
-export const SITE_CONFIGS_REVISION = 2;
+export const SITE_CONFIGS_REVISION = 3;
 
 export const SITE_CONFIGS = [
   { hostname: "chatgpt.com", matchPatterns: ["https://chatgpt.com/*"] },
@@ -44,11 +42,11 @@ export const SITE_CONFIGS = [
   { hostname: "grok.com", matchPatterns: ["https://grok.com/*"] },
   { hostname: "www.perplexity.ai", matchPatterns: ["https://www.perplexity.ai/*"] },
   { hostname: "chat.mistral.ai", matchPatterns: ["https://chat.mistral.ai/*"] },
-  { hostname: "notebook.google.com", matchPatterns: ["https://notebook.google.com/*"] },
+  { hostname: "notebook.google.com", matchPatterns: ["https://notebook.google.com/*"], optional: true },
   { hostname: "github.com", matchPatterns: ["https://github.com/copilot*", "https://github.com/spark*"] },
   { hostname: "poe.com", matchPatterns: ["https://poe.com/*"] },
   { hostname: "v0.app", matchPatterns: ["https://v0.app/*"] },
-  { hostname: "www.kimi.com", matchPatterns: ["https://www.kimi.com/*"] },
+  { hostname: "www.kimi.com", matchPatterns: ["https://www.kimi.com/*"], optional: true },
   { hostname: "cursor.com", matchPatterns: ["https://cursor.com/agents*", "https://cursor.com/*/agents*"], optional: true },
   { hostname: "www.genspark.ai", matchPatterns: ["https://www.genspark.ai/*"], optional: true },
   { hostname: "duck.ai", matchPatterns: ["https://duck.ai/*"], optional: true },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",
@@ -27,12 +27,10 @@
         "https://grok.com/*",
         "https://www.perplexity.ai/*",
         "https://chat.mistral.ai/*",
-        "https://notebook.google.com/*",
         "https://github.com/copilot*",
         "https://github.com/spark*",
         "https://poe.com/*",
-        "https://v0.app/*",
-        "https://www.kimi.com/*"
+        "https://v0.app/*"
       ],
       "js": [
         "content/ctrl-enter-utils.js",
@@ -52,7 +50,6 @@
     "https://chat.mistral.ai/*",
     "https://www.perplexity.ai/*",
     "https://claude.ai/*",
-    "https://notebook.google.com/*",
     "https://gemini.google.com/*",
     "https://v0.app/*",
     "https://chat.deepseek.com/*",
@@ -60,10 +57,11 @@
     "https://github.com/spark*",
     "https://grok.com/*",
     "https://copilot.microsoft.com/*",
-    "https://m365.cloud.microsoft/*",
-    "https://www.kimi.com/*"
+    "https://m365.cloud.microsoft/*"
   ],
   "optional_host_permissions": [
+    "https://notebook.google.com/*",
+    "https://www.kimi.com/*",
     "https://cursor.com/agents*",
     "https://cursor.com/*/agents*",
     "https://www.genspark.ai/*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-ctrl-enter-sender",
-      "version": "2.5.1",
+      "version": "2.5.2",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "private": true,
   "description": "Browser extension that assigns Ctrl+Enter to send messages in ChatGPT and other AI chat sites, so Enter inserts a line break",
   "main": "service-worker.js",

--- a/tests/mock-sites.spec.js
+++ b/tests/mock-sites.spec.js
@@ -66,14 +66,6 @@ const MOCK_SITES = [
     inputSelector: "#prompt",
   },
   {
-    name: "NotebookLM",
-    url: "https://notebook.google.com/",
-    route: "https://notebook.google.com/**",
-    markup: '<query-box><form><textarea id="prompt" class="query-box-input"></textarea><button type="submit">Send</button></form></query-box>',
-    inputSelector: "#prompt",
-    submitViaButton: true,
-  },
-  {
     name: "GitHub Copilot",
     url: "https://github.com/copilot",
     route: "https://github.com/**",
@@ -92,13 +84,6 @@ const MOCK_SITES = [
     url: "https://v0.app/",
     route: "https://v0.app/**",
     markup: '<textarea id="prompt"></textarea>',
-    inputSelector: "#prompt",
-  },
-  {
-    name: "Kimi",
-    url: "https://www.kimi.com/",
-    route: "https://www.kimi.com/**",
-    markup: '<div id="prompt" contenteditable="true" data-lexical-editor="true" role="textbox"></div>',
     inputSelector: "#prompt",
   },
 ];

--- a/tests/permission-warnings.spec.js
+++ b/tests/permission-warnings.spec.js
@@ -43,6 +43,14 @@ test.describe("Permission Warnings", () => {
     const baseline = fs.readFileSync(BASELINE_MANIFEST, "utf-8");
     const current = fs.readFileSync(CURRENT_MANIFEST, "utf-8");
 
+    const baselineRequiredHosts = new Set(JSON.parse(baseline).host_permissions ?? []);
+    for (const host of JSON.parse(current).host_permissions ?? []) {
+      expect(
+        baselineRequiredHosts,
+        `New required host permission would disable the extension on update: "${host}"`
+      ).toContain(host);
+    }
+
     const baselineWarnings = await getPermissionWarnings(serviceWorker, baseline);
     const currentWarnings = await getPermissionWarnings(serviceWorker, current);
 

--- a/tools/ctrl-enter-handler.test.js
+++ b/tools/ctrl-enter-handler.test.js
@@ -390,6 +390,18 @@ test("Manus の Ctrl+Enter は通常 Enter にマッピングする", () => {
 
 // ── NotebookLM tests ────────────────────────────────────────────────────────
 
+test("NotebookLM の Enter は Shift+Enter にマッピングする", () => {
+  const context = loadHandler("https://notebook.google.com/", createButton(), notebookSubmitSelector);
+  const { target, dispatchedEvents } = createTextareaTarget();
+  target.classList = { contains: (name) => name === "query-box-input" };
+  const event = createKeydownEvent(target);
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(dispatchedEvents.length, 1);
+  assert.equal(dispatchedEvents[0].shiftKey, true);
+});
+
 test("NotebookLM の Ctrl+Enter は送信ボタンだけを一度クリックする", () => {
   const sendButton = createButton();
   const context = loadHandler(
@@ -425,6 +437,34 @@ test("NotebookLM の送信ボタンがない場合は通常 Enter にフォー�
   assert.equal(dispatchedEvents[0].shiftKey, undefined);
   assert.equal(event.preventDefaultCount, 1);
   assert.equal(event.stopImmediatePropagationCount, 1);
+});
+
+// ── Kimi tests ──────────────────────────────────────────────────────────────
+
+test("Kimi の Enter は Shift+Enter にマッピングする", () => {
+  const context = loadHandler("https://www.kimi.com/", createButton());
+  const { target, dispatchedEvents } = createLexicalTarget();
+  const event = createKeydownEvent(target);
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(event.stopImmediatePropagationCount, 1);
+  assert.equal(dispatchedEvents.length, 1);
+  assert.equal(dispatchedEvents[0].shiftKey, true);
+});
+
+test("Kimi の Ctrl+Enter は通常 Enter にマッピングする", () => {
+  const context = loadHandler("https://www.kimi.com/", createButton());
+  const { target, dispatchedEvents } = createLexicalTarget();
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(event.stopImmediatePropagationCount, 1);
+  assert.equal(dispatchedEvents.length, 1);
+  assert.equal(dispatchedEvents[0].shiftKey, undefined);
 });
 
 // ── General behavior tests ───────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- move the new NotebookLM hostname and Kimi back to optional host permissions
- prevent future required-host additions from passing the permission regression test
- update site classification documentation and preserve behavior coverage for optional sites
- bump the emergency release to 2.5.2

## Impact
- users on 2.5.0 can update directly to 2.5.2 without a required permission increase
- users disabled by the 2.5.1 permission increase can recover when Chromium removes the permission-increase disable reason

## Validation
- 2.5.0 -> 2.5.2 added required patterns: none
- `npm test` (54 unit, 24 integration passed)
- `python tools/check_supported_sites.py`
- `python -m unittest tools/test_check_site_urls.py` (7 passed)