### PR TITLE
Prepare v2.5.3 after Web Store rollback

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chatgpt-ctrl-enter-sender",
-      "version": "2.5.2",
+      "version": "2.5.3",
       "license": "MIT",
       "devDependencies": {
         "@playwright/test": "^1.58.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chatgpt-ctrl-enter-sender",
-  "version": "2.5.2",
+  "version": "2.5.3",
   "private": true,
   "description": "Browser extension that assigns Ctrl+Enter to send messages in ChatGPT and other AI chat sites, so Enter inserts a line break",
   "main": "service-worker.js",

--- a/tests/baseline-manifest.json
+++ b/tests/baseline-manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_appName__",
-  "version": "2.5.0",
+  "version": "2.5.2",
   "description": "__MSG_appDesc__",
   "default_locale": "en",
   "author": "Kamada Masachika",


### PR DESCRIPTION
## Summary
- bump the corrected package to 2.5.3 after the Chrome Web Store rollback consumed version 2.5.2
- record the rolled-back 2.5.2 package as the published permission baseline

## Validation
- 2.5.2 rollback -> 2.5.3 added required patterns: none
- `npm test` (54 unit, 24 integration passed)
- `python tools/check_supported_sites.py`
- `python -m unittest tools/test_check_site_urls.py` (7 passed)