### PR TITLE
Harden site URL monitoring

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -91,12 +91,14 @@ outside this extension's control.
 
 The `Site URL Monitor` workflow checks every configured hostname once a day. It
 follows redirects and opens one tracking issue when a site moves to an
-unexpected hostname or cannot be reached after two attempts. The same issue is
-updated on later failures and closed automatically after recovery.
+unexpected hostname or cannot be reached after three attempts with short retry
+delays. The same issue is updated on later failures and closed automatically
+after recovery.
 
-HTTP 401, 403 and 404 responses still count as reachable because many supported
-sites block automated clients. This monitor detects hostname moves and outages;
-it does not prove that the chat input selectors still work. Run it locally with:
+HTTP 401 and 403 responses still count as reachable because many supported sites
+block automated clients. HTTP 404 is reported because it can indicate that the
+configured destination has been removed. This monitor detects hostname moves and
+outages; it does not prove that the chat input selectors still work. Run it locally with:
 
 ```shell
 python tools/check_site_urls.py --output site-url-report.md

--- a/tools/check_site_urls.py
+++ b/tools/check_site_urls.py
@@ -3,6 +3,7 @@ import json
 import re
 import socket
 import sys
+import time
 import urllib.error
 import urllib.request
 from dataclasses import dataclass
@@ -13,7 +14,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 SITE_CONFIGS_PATH = REPO_ROOT / "constants" / "site-configs.js"
 USER_AGENT = "Mozilla/5.0 (compatible; ChatGPT-Ctrl-Enter-Sender-Site-Monitor/1.0)"
 TIMEOUT_SECONDS = 20
-ATTEMPTS = 2
+RETRY_DELAYS_SECONDS = (5, 15)
+ATTEMPTS = len(RETRY_DELAYS_SECONDS) + 1
 
 ALLOWED_EXTERNAL_REDIRECTS = {
     "notebook.google.com": {"accounts.google.com"},
@@ -86,6 +88,9 @@ def classify(hostname, result):
         hosts = ", ".join(f"`{host}`" for host in unexpected)
         return CheckResult(hostname, False, f"redirected through unexpected host(s): {hosts}")
 
+    if result.status == 404:
+        return CheckResult(hostname, False, f"HTTP 404 at `{display_url(result.final_url)}`")
+
     return CheckResult(
         hostname,
         True,
@@ -93,13 +98,20 @@ def classify(hostname, result):
     )
 
 
-def check_hostname(hostname, probe_func=probe):
+def describe_error(error):
+    message = str(error).strip()
+    return f"{type(error).__name__}: {message}" if message else type(error).__name__
+
+
+def check_hostname(hostname, probe_func=probe, sleep_func=time.sleep):
     errors = []
-    for _ in range(ATTEMPTS):
+    for attempt in range(ATTEMPTS):
         try:
             return classify(hostname, probe_func(hostname))
         except (OSError, socket.timeout, urllib.error.URLError) as error:
-            errors.append(str(error))
+            errors.append(describe_error(error))
+            if attempt < len(RETRY_DELAYS_SECONDS):
+                sleep_func(RETRY_DELAYS_SECONDS[attempt])
 
     return CheckResult(hostname, False, f"unreachable after {ATTEMPTS} attempts: {errors[-1]}")
 
@@ -115,7 +127,7 @@ def render_report(results):
         "## Supported site URL monitor",
         "",
         summary,
-        "HTTP 401/403/404 responses are treated as reachable; unexpected cross-host redirects are not.",
+        "HTTP 401/403 responses are treated as reachable; HTTP 404 and unexpected cross-host redirects are not.",
         "",
         "| Configured host | Result | Detail |",
         "| --- | --- | --- |",

--- a/tools/test_check_site_urls.py
+++ b/tools/test_check_site_urls.py
@@ -17,6 +17,12 @@ class SiteUrlMonitorTests(unittest.TestCase):
         classified = classify("poe.com", result)
         self.assertTrue(classified.healthy)
 
+    def test_not_found_status_is_unhealthy(self):
+        result = ProbeResult(404, "https://old.example/", [])
+        classified = classify("old.example", result)
+        self.assertFalse(classified.healthy)
+        self.assertIn("HTTP 404", classified.detail)
+
     def test_unexpected_redirect_host_is_reported(self):
         result = ProbeResult(200, "https://new.example/", ["new.example"])
         classified = classify("old.example", result)
@@ -40,16 +46,26 @@ class SiteUrlMonitorTests(unittest.TestCase):
 
     def test_network_failure_is_retried(self):
         attempts = 0
+        delays = []
 
         def failing_probe(_hostname):
             nonlocal attempts
             attempts += 1
             raise urllib.error.URLError("temporary failure")
 
-        result = check_hostname("example.com", failing_probe)
-        self.assertEqual(attempts, 2)
+        result = check_hostname("example.com", failing_probe, delays.append)
+        self.assertEqual(attempts, 3)
+        self.assertEqual(delays, [5, 15])
         self.assertFalse(result.healthy)
-        self.assertIn("after 2 attempts", result.detail)
+        self.assertIn("after 3 attempts", result.detail)
+        self.assertIn("URLError: <urlopen error temporary failure>", result.detail)
+
+    def test_empty_network_error_includes_exception_type(self):
+        def failing_probe(_hostname):
+            raise TimeoutError()
+
+        result = check_hostname("example.com", failing_probe, lambda _delay: None)
+        self.assertTrue(result.detail.endswith(": TimeoutError"))
 
     def test_report_includes_failure_count(self):
         report = render_report([


### PR DESCRIPTION
## Summary
- retry site URL probes three times with 5s/15s backoff
- include exception types in network failure reports
- treat HTTP 404 as a monitor failure while preserving 401/403 handling
- document and test the updated behavior

Related to #158.

## Tests
- `npm test`
- `python -m unittest tools/test_check_site_urls.py`
- `python tools/check_site_urls.py --output site-url-report.md` (18/18 passed)