### PR TITLE
[fix] claude ctrl+enter not sending in narrow windows

### DIFF
--- a/content/ctrl-enter-handler.js
+++ b/content/ctrl-enter-handler.js
@@ -98,7 +98,13 @@ const SITE_BEHAVIORS = {
           dispatchEnter(event.target, {});
         }
       } else {
-        dispatchEnter(event.target, {});
+        // Narrow layouts treat plain Enter as newline; click the send button instead
+        const sendButton = document.querySelector('button[data-testid="chat-input-send"]:not([disabled])');
+        if (sendButton) {
+          sendButton.click();
+        } else {
+          dispatchEnter(event.target, {});
+        }
       }
     },
   },

--- a/tools/ctrl-enter-handler.test.js
+++ b/tools/ctrl-enter-handler.test.js
@@ -9,6 +9,7 @@ const handlerScript = fs.readFileSync(handlerScriptPath, "utf8");
 const submitSelector = 'button[type="submit"]:not([disabled])';
 const notebookSubmitSelector = 'query-box form button[type="submit"]';
 const claudeSaveSelector = 'button:not([disabled]):has(> span.bg-fill-primary)';
+const claudeSendSelector = 'button[data-testid="chat-input-send"]:not([disabled])';
 
 function loadHandler(url, sendButton, documentButtonSelector = submitSelector) {
   const parsedUrl = new URL(url);
@@ -271,7 +272,26 @@ test("Claude の保存ボタンが見つからない場合は通常 Enter にフ
   assert.equal(dispatchedEvents[0].shiftKey, undefined);
 });
 
-test("Claude の入力欄（contenteditable）の Ctrl+Enter は通常 Enter を送る", () => {
+test("Claude の入力欄（contenteditable）の Ctrl+Enter は送信ボタンを一度クリックする", () => {
+  const sendButton = createButton();
+  const dispatchedEvents = [];
+  const target = {
+    tagName: "DIV",
+    contentEditable: "true",
+    dispatchEvent: (e) => { dispatchedEvents.push(e); return true; }
+  };
+  const context = loadHandler("https://claude.ai/chat/abc", sendButton, claudeSendSelector);
+  const event = createKeydownEvent(target, { ctrlKey: true });
+
+  context.handleCtrlEnter(event);
+
+  assert.equal(sendButton.clickCount, 1);
+  assert.equal(dispatchedEvents.length, 0);
+  assert.equal(event.preventDefaultCount, 1);
+  assert.equal(event.stopImmediatePropagationCount, 1);
+});
+
+test("Claude の送信ボタンが見つからない場合は通常 Enter にフォールバックする", () => {
   const dispatchedEvents = [];
   const target = {
     tagName: "DIV",


### PR DESCRIPTION
Closes #160

## 概要

ウィンドウ幅が狭いときにClaudeの入力欄でCtrl+Enterを押してもメッセージが送信されない問題を修正しました。Claudeは一定幅以下でモバイル向けレイアウトに切り替わり，素のEnterを「送信」ではなく「改行」として扱うため，`onCtrlEnter`が合成する素のEnterイベントでは送信されなくなっていました。

## 変更点

`content/ctrl-enter-handler.js`にある`onCtrlEnter`関数の入力欄（contenteditable）側の分岐を修正しました。

- 合成Enterのディスパッチから，送信ボタン（`button[data-testid="chat-input-send"]:not([disabled])`）のクリックに変更しました。送信ボタンはウィンドウ幅に関係なく存在することを確認しています。
- 送信ボタンが見つからない場合は，従来どおり通常のEnterイベントをディスパッチするフォールバック処理を残しています。

編集モード（TEXTAREA側）は変更していません。

## テスト

`tools/ctrl-enter-handler.test.js`にテストケースを追加しました。

- 入力欄（contenteditable）でのCtrl+Enterが送信ボタンを一度だけクリックすること
- 送信ボタンが見つからない場合に通常のEnterへフォールバックすること

`npm test`が全件通過することを確認済みです。また，広い幅・狭い幅の両方で実際に送信されることを実機（Windows 11 / Chrome）で確認しました。